### PR TITLE
Enhance API coverage tests by updating to OpenAPI 3.1

### DIFF
--- a/tests_api_coverage/api_definition.json
+++ b/tests_api_coverage/api_definition.json
@@ -1,10 +1,6074 @@
 {
-    "components": {"schemas":{"apimodel.CheckboxPropertyLinkValue":{"properties":{"checkbox":{"description":"The checkbox value of the property","example":true,"type":"boolean"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"done","type":"string"}},"type":"object"},"apimodel.CheckboxPropertyValue":{"properties":{"checkbox":{"description":"The checkbox value of the property","example":true,"type":"boolean"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"done","type":"string"},"name":{"description":"The name of the property","example":"Done","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.Color":{"description":"The color of the icon","enum":["grey","yellow","orange","red","pink","purple","blue","ice","teal","lime"],"example":"yellow","type":"string","x-enum-varnames":["ColorGrey","ColorYellow","ColorOrange","ColorRed","ColorPink","ColorPurple","ColorBlue","ColorIce","ColorTeal","ColorLime"]},"apimodel.CreateObjectRequest":{"properties":{"body":{"description":"The body of the object","example":"This is the body of the object. Markdown syntax is supported here.","type":"string"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"name":{"description":"The name of the object","example":"My object","type":"string"},"properties":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set on the object","items":{"$ref":"#/components/schemas/apimodel.PropertyLinkWithValue"},"type":"array","uniqueItems":false},"template_id":{"description":"The id of the template to use","example":"bafyreictrp3obmnf6dwejy5o4p7bderaaia4bdg2psxbfzf44yya5uutge","type":"string"},"type_key":{"description":"The key of the type of object to create","example":"page","type":"string"}},"required":["type_key"],"type":"object"},"apimodel.CreatePropertyRequest":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"name":{"description":"The name of the property","example":"Last modified date","type":"string"}},"required":["format","name"],"type":"object"},"apimodel.CreateSpaceRequest":{"properties":{"description":{"description":"The description of the space","example":"The local-first wiki","type":"string"},"name":{"description":"The name of the space","example":"New Space","type":"string"}},"required":["name"],"type":"object"},"apimodel.CreateTagRequest":{"properties":{"color":{"$ref":"#/components/schemas/apimodel.Color"},"name":{"description":"The name of the tag","example":"In progress","type":"string"}},"required":["color","name"],"type":"object"},"apimodel.CreateTypeRequest":{"properties":{"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"layout":{"$ref":"#/components/schemas/apimodel.TypeLayout"},"name":{"description":"The name of the type","example":"Page","type":"string"},"plural_name":{"description":"The plural name of the type","example":"Pages","type":"string"},"properties":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties linked to the type","items":{"$ref":"#/components/schemas/apimodel.PropertyLink"},"type":"array","uniqueItems":false}},"required":["layout","name"],"type":"object"},"apimodel.DatePropertyLinkValue":{"properties":{"date":{"description":"The date value of the property","example":"2025-02-14T12:34:56Z","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"last_modified_date","type":"string"}},"type":"object"},"apimodel.DatePropertyValue":{"properties":{"date":{"description":"The date value of the property","example":"2025-02-14T12:34:56Z","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"last_modified_date","type":"string"},"name":{"description":"The name of the property","example":"Last modified date","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.DisplayCodeResponse":{"properties":{"challenge_id":{"description":"The challenge id associated with the displayed code and needed to solve the challenge for token","example":"67647f5ecda913e9a2e11b26","type":"string"}},"type":"object"},"apimodel.EmailPropertyLinkValue":{"properties":{"email":{"description":"The email value of the property","example":"example@example.com","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"email","type":"string"}},"type":"object"},"apimodel.EmailPropertyValue":{"properties":{"email":{"description":"The email value of the property","example":"example@example.com","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"email","type":"string"},"name":{"description":"The name of the property","example":"Email","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.EmojiIcon":{"properties":{"emoji":{"description":"The emoji of the icon","example":"📄","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.IconFormat"}},"type":"object"},"apimodel.FileIcon":{"properties":{"file":{"description":"The file of the icon","example":"bafybeieptz5hvcy6txplcvphjbbh5yjc2zqhmihs3owkh5oab4ezauzqay","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.IconFormat"}},"type":"object"},"apimodel.FilesPropertyLinkValue":{"properties":{"files":{"description":"The file values of the property","example":["['fileId']"],"items":{"type":"string"},"type":"array","uniqueItems":false},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"files","type":"string"}},"type":"object"},"apimodel.FilesPropertyValue":{"properties":{"files":{"description":"The file values of the property","example":["['fileId']"],"items":{"type":"string"},"type":"array","uniqueItems":false},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"files","type":"string"},"name":{"description":"The name of the property","example":"Files","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.Filter":{"properties":{"condition":{"description":"The filter condition","enum":["equal","not_equal","greater","less","greater_or_equal","less_or_equal","like","not_like","in","not_in","empty","not_empty","all_in","not_all_in","exact_in","not_exact_in","exists"],"example":"contains","type":"string"},"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the filter","example":"67bf3f21cda9134102e2422c","type":"string"},"property_key":{"description":"The property key used for filtering","example":"name","type":"string"},"value":{"description":"The value used for filtering","example":"Some value...","type":"string"}},"type":"object"},"apimodel.Icon":{"description":"The icon of the object","oneOf":[{"$ref":"#/components/schemas/apimodel.EmojiIcon"},{"$ref":"#/components/schemas/apimodel.FileIcon"},{"$ref":"#/components/schemas/apimodel.NamedIcon"}],"type":"object"},"apimodel.IconFormat":{"description":"The format of the icon","enum":["icon"],"type":"string","x-enum-varnames":["IconFormatEmoji","IconFormatFile","IconFormatIcon"]},"apimodel.Member":{"description":"The member","properties":{"global_name":{"description":"The global name of the member in the network","example":"john.any","type":"string"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"id":{"description":"The profile object id of the member","example":"_participant_bafyreigyfkt6rbv24sbv5aq2hko1bhmv5xxlf22b4bypdu6j7hnphm3psq_23me69r569oi1_AAjEaEwPF4nkEh9AWkqEnzcQ8HziBB4ETjiTpvRCQvWnSMDZ","type":"string"},"identity":{"description":"The identity of the member in the network","example":"AAjEaEwPF4nkEh7AWkqEnzcQ8HziGB4ETjiTpvRCQvWnSMDZ","type":"string"},"name":{"description":"The name of the member","example":"John Doe","type":"string"},"object":{"description":"The data model of the object","example":"member","type":"string"},"role":{"description":"The role of the member","enum":["viewer","editor","owner","no_permission"],"example":"owner","type":"string"},"status":{"description":"The status of the member","enum":["joining","active","removed","declined","removing","canceled"],"example":"active","type":"string"}},"type":"object"},"apimodel.MemberResponse":{"properties":{"member":{"$ref":"#/components/schemas/apimodel.Member"}},"type":"object"},"apimodel.MultiSelectPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"tag","type":"string"},"multi_select":{"description":"The selected tag values of the property","items":{"type":"string"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.MultiSelectPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"tag","type":"string"},"multi_select":{"description":"The selected tag values of the property","items":{"$ref":"#/components/schemas/apimodel.Tag"},"type":"array","uniqueItems":false},"name":{"description":"The name of the property","example":"Tag","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.NamedIcon":{"properties":{"color":{"$ref":"#/components/schemas/apimodel.Color"},"format":{"$ref":"#/components/schemas/apimodel.IconFormat"},"name":{"description":"The name of the icon","example":"document","type":"string"}},"type":"object"},"apimodel.NumberPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"height","type":"string"},"number":{"description":"The number value of the property","example":42,"type":"number"}},"type":"object"},"apimodel.NumberPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"height","type":"string"},"name":{"description":"The name of the property","example":"Height","type":"string"},"number":{"description":"The number value of the property","example":42,"type":"number"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.Object":{"properties":{"archived":{"description":"Whether the object is archived","example":false,"type":"boolean"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"id":{"description":"The id of the object","example":"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ","type":"string"},"layout":{"$ref":"#/components/schemas/apimodel.ObjectLayout"},"name":{"description":"The name of the object","example":"My object","type":"string"},"object":{"description":"The data model of the object","example":"object","type":"string"},"properties":{"description":"The properties of the object","items":{"$ref":"#/components/schemas/apimodel.PropertyWithValue"},"type":"array","uniqueItems":false},"snippet":{"description":"The snippet of the object, especially important for notes as they don't have a name","example":"The beginning of the object body...","type":"string"},"space_id":{"description":"The id of the space the object is in","example":"bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1","type":"string"},"type":{"$ref":"#/components/schemas/apimodel.Type"}},"type":"object"},"apimodel.ObjectLayout":{"description":"The layout of the object","example":"basic","type":"string","x-enum-varnames":["ObjectLayoutBasic","ObjectLayoutProfile","ObjectLayoutAction","ObjectLayoutNote","ObjectLayoutBookmark","ObjectLayoutSet","ObjectLayoutCollection","ObjectLayoutParticipant"]},"apimodel.ObjectResponse":{"properties":{"object":{"$ref":"#/components/schemas/apimodel.ObjectWithBody"}},"type":"object"},"apimodel.ObjectWithBody":{"description":"The object","properties":{"archived":{"description":"Whether the object is archived","example":false,"type":"boolean"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"id":{"description":"The id of the object","example":"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ","type":"string"},"layout":{"description":"The layout of the object","example":"basic","type":"string","x-enum-varnames":["ObjectLayoutBasic","ObjectLayoutProfile","ObjectLayoutAction","ObjectLayoutNote","ObjectLayoutBookmark","ObjectLayoutSet","ObjectLayoutCollection","ObjectLayoutParticipant"]},"markdown":{"description":"The markdown body of the object","example":"# This is the title\n...","type":"string"},"name":{"description":"The name of the object","example":"My object","type":"string"},"object":{"description":"The data model of the object","example":"object","type":"string"},"properties":{"description":"The properties of the object","items":{"$ref":"#/components/schemas/apimodel.PropertyWithValue"},"type":"array","uniqueItems":false},"snippet":{"description":"The snippet of the object, especially important for notes as they don't have a name","example":"The beginning of the object body...","type":"string"},"space_id":{"description":"The id of the space the object is in","example":"bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1","type":"string"},"type":{"$ref":"#/components/schemas/apimodel.Type"}},"type":"object"},"apimodel.ObjectsPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"creator","type":"string"},"objects":{"description":"The object values of the property","example":["['objectId']"],"items":{"type":"string"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.ObjectsPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"creator","type":"string"},"name":{"description":"The name of the property","example":"Created by","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"},"objects":{"description":"The object values of the property","example":["['objectId']"],"items":{"type":"string"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.PhonePropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"phone","type":"string"},"phone":{"description":"The phone value of the property","example":"+1234567890","type":"string"}},"type":"object"},"apimodel.PhonePropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"phone","type":"string"},"name":{"description":"The name of the property","example":"Phone","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"},"phone":{"description":"The phone value of the property","example":"+1234567890","type":"string"}},"type":"object"},"apimodel.Property":{"description":"The property","properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"last_modified_date","type":"string"},"name":{"description":"The name of the property","example":"Last modified date","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"}},"type":"object"},"apimodel.PropertyFormat":{"description":"The format of the property used for filtering","enum":["text","number","select","multi_select","date","files","checkbox","url","email","phone","objects"],"type":"string","x-enum-varnames":["PropertyFormatText","PropertyFormatNumber","PropertyFormatSelect","PropertyFormatMultiSelect","PropertyFormatDate","PropertyFormatFiles","PropertyFormatCheckbox","PropertyFormatUrl","PropertyFormatEmail","PropertyFormatPhone","PropertyFormatObjects"]},"apimodel.PropertyLink":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"description":"The key of the property","example":"last_modified_date","type":"string"},"name":{"description":"The name of the property","example":"Last modified date","type":"string"}},"required":["format","key","name"],"type":"object"},"apimodel.PropertyLinkWithValue":{"oneOf":[{"$ref":"#/components/schemas/apimodel.TextPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.NumberPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.SelectPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.MultiSelectPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.DatePropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.FilesPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.CheckboxPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.URLPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.EmailPropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.PhonePropertyLinkValue"},{"$ref":"#/components/schemas/apimodel.ObjectsPropertyLinkValue"}],"type":"object"},"apimodel.PropertyResponse":{"properties":{"property":{"$ref":"#/components/schemas/apimodel.Property"}},"type":"object"},"apimodel.PropertyWithValue":{"oneOf":[{"$ref":"#/components/schemas/apimodel.TextPropertyValue"},{"$ref":"#/components/schemas/apimodel.NumberPropertyValue"},{"$ref":"#/components/schemas/apimodel.SelectPropertyValue"},{"$ref":"#/components/schemas/apimodel.MultiSelectPropertyValue"},{"$ref":"#/components/schemas/apimodel.DatePropertyValue"},{"$ref":"#/components/schemas/apimodel.FilesPropertyValue"},{"$ref":"#/components/schemas/apimodel.CheckboxPropertyValue"},{"$ref":"#/components/schemas/apimodel.URLPropertyValue"},{"$ref":"#/components/schemas/apimodel.EmailPropertyValue"},{"$ref":"#/components/schemas/apimodel.PhonePropertyValue"},{"$ref":"#/components/schemas/apimodel.ObjectsPropertyValue"}],"type":"object"},"apimodel.SearchRequest":{"properties":{"query":{"description":"The search term to look for in object names and snippets","example":"test","type":"string"},"sort":{"$ref":"#/components/schemas/apimodel.SortOptions"},"types":{"description":"The types of objects to search for, specified by key or ID","example":["page","678043f0cda9133be777049f","bafyreightzrdts2ymxyaeyzspwdfo2juspyam76ewq6qq7ixnw3523gs7q"],"items":{"type":"string"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.SelectPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"status","type":"string"},"select":{"description":"The selected tag value of the property","type":"string"}},"type":"object"},"apimodel.SelectPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"status","type":"string"},"name":{"description":"The name of the property","example":"Status","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"},"select":{"$ref":"#/components/schemas/apimodel.Tag"}},"type":"object"},"apimodel.Sort":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the sort","example":"67bf3f21cda9134102e2422c","type":"string"},"property_key":{"description":"The property key used for sorting","example":"name","type":"string"},"sort_type":{"description":"The sort direction","enum":["asc","desc","custom"],"example":"asc","type":"string"}},"type":"object"},"apimodel.SortDirection":{"default":"desc","description":"The direction to sort the search results","enum":["asc","desc"],"type":"string","x-enum-varnames":["Asc","Desc"]},"apimodel.SortOptions":{"description":"The sorting criteria and direction for the search results","properties":{"direction":{"$ref":"#/components/schemas/apimodel.SortDirection"},"property_key":{"$ref":"#/components/schemas/apimodel.SortProperty"}},"type":"object"},"apimodel.SortProperty":{"default":"last_modified_date","description":"The property to sort the search results by","enum":["created_date","last_modified_date","last_opened_date","name"],"type":"string","x-enum-varnames":["CreatedDate","LastModifiedDate","LastOpenedDate","Name"]},"apimodel.Space":{"description":"The space","properties":{"description":{"description":"The description of the space","example":"The local-first wiki","type":"string"},"gateway_url":{"description":"The gateway url to serve files and media","example":"http://127.0.0.1:31006","type":"string"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"id":{"description":"The id of the space","example":"bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1","type":"string"},"name":{"description":"The name of the space","example":"My Space","type":"string"},"network_id":{"description":"The network id of the space","example":"N83gJpVd9MuNRZAuJLZ7LiMntTThhPc6DtzWWVjb1M3PouVU","type":"string"},"object":{"description":"The data model of the object","example":"space","type":"string"}},"type":"object"},"apimodel.SpaceResponse":{"properties":{"space":{"$ref":"#/components/schemas/apimodel.Space"}},"type":"object"},"apimodel.Tag":{"description":"The selected tag value of the property","properties":{"color":{"$ref":"#/components/schemas/apimodel.Color"},"id":{"description":"The id of the tag","example":"bafyreiaixlnaefu3ci22zdenjhsdlyaeeoyjrsid5qhfeejzlccijbj7sq","type":"string"},"key":{"description":"The key of the tag","example":"67b0d3e3cda913b84c1299b1","type":"string"},"name":{"description":"The name of the tag","example":"in-progress","type":"string"},"object":{"description":"The data model of the object","example":"tag","type":"string"}},"type":"object"},"apimodel.TagResponse":{"properties":{"tag":{"$ref":"#/components/schemas/apimodel.Tag"}},"type":"object"},"apimodel.TemplateResponse":{"properties":{"template":{"$ref":"#/components/schemas/apimodel.ObjectWithBody"}},"type":"object"},"apimodel.TextPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"description","type":"string"},"text":{"description":"The text value of the property","example":"Some text...","type":"string"}},"type":"object"},"apimodel.TextPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"description","type":"string"},"name":{"description":"The name of the property","example":"Description","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"},"text":{"description":"The text value of the property","example":"Some text...","type":"string"}},"type":"object"},"apimodel.TokenResponse":{"properties":{"app_key":{"description":"The app key used to authenticate requests","example":"zhSG/zQRmgADyilWPtgdnfo1qD60oK02/SVgi1GaFt6=","type":"string"}},"type":"object"},"apimodel.Type":{"description":"The type of the object","properties":{"archived":{"description":"Whether the type is archived","example":false,"type":"boolean"},"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"id":{"description":"The id of the type (which is unique across spaces)","example":"bafyreigyb6l5szohs32ts26ku2j42yd65e6hqy2u3gtzgdwqv6hzftsetu","type":"string"},"key":{"description":"The key of the type (can be the same across spaces for known types)","example":"page","type":"string"},"layout":{"description":"The layout of the object","example":"basic","type":"string","x-enum-varnames":["ObjectLayoutBasic","ObjectLayoutProfile","ObjectLayoutAction","ObjectLayoutNote","ObjectLayoutBookmark","ObjectLayoutSet","ObjectLayoutCollection","ObjectLayoutParticipant"]},"name":{"description":"The name of the type","example":"Page","type":"string"},"object":{"description":"The data model of the object","example":"type","type":"string"},"plural_name":{"description":"The plural name of the type","example":"Pages","type":"string"},"properties":{"description":"The properties linked to the type","items":{"$ref":"#/components/schemas/apimodel.Property"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.TypeLayout":{"description":"The layout of the type","example":"basic","type":"string","x-enum-varnames":["TypeLayoutBasic","TypeLayoutProfile","TypeLayoutAction","TypeLayoutNote"]},"apimodel.TypeResponse":{"properties":{"type":{"$ref":"#/components/schemas/apimodel.Type"}},"type":"object"},"apimodel.URLPropertyLinkValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"key":{"example":"source","type":"string"},"url":{"description":"The URL value of the property","example":"https://example.com","type":"string"}},"type":"object"},"apimodel.URLPropertyValue":{"properties":{"format":{"$ref":"#/components/schemas/apimodel.PropertyFormat"},"id":{"description":"The id of the property","example":"bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a","type":"string"},"key":{"description":"The key of the property","example":"source","type":"string"},"name":{"description":"The name of the property","example":"Source","type":"string"},"object":{"description":"The data model of the object","example":"property","type":"string"},"url":{"description":"The URL value of the property","example":"https://example.com","type":"string"}},"type":"object"},"apimodel.UpdateObjectRequest":{"properties":{"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"name":{"description":"The name of the object","example":"My object","type":"string"},"properties":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set for the object","items":{"$ref":"#/components/schemas/apimodel.PropertyLinkWithValue"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.UpdatePropertyRequest":{"properties":{"name":{"description":"The name to set for the property","example":"Last modified date","type":"string"}},"required":["name"],"type":"object"},"apimodel.UpdateSpaceRequest":{"properties":{"description":{"description":"The description of the space","example":"The local-first wiki","type":"string"},"name":{"description":"The name of the space","example":"New Space","type":"string"}},"type":"object"},"apimodel.UpdateTagRequest":{"properties":{"color":{"$ref":"#/components/schemas/apimodel.Color"},"name":{"description":"The name to set for the tag","example":"In progress","type":"string"}},"type":"object"},"apimodel.UpdateTypeRequest":{"properties":{"icon":{"$ref":"#/components/schemas/apimodel.Icon"},"layout":{"description":"The layout of the type","example":"basic","type":"string","x-enum-varnames":["TypeLayoutBasic","TypeLayoutProfile","TypeLayoutAction","TypeLayoutNote"]},"name":{"description":"The name to set for the type","example":"Page","type":"string"},"plural_name":{"description":"The plural name to set for the type","example":"Pages","type":"string"},"properties":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set for the type","items":{"$ref":"#/components/schemas/apimodel.PropertyLink"},"type":"array","uniqueItems":false}},"type":"object"},"apimodel.View":{"properties":{"filters":{"description":"The list of filters","items":{"$ref":"#/components/schemas/apimodel.Filter"},"type":"array","uniqueItems":false},"id":{"description":"The id of the view","example":"67bf3f21cda9134102e2422c","type":"string"},"layout":{"description":"The layout of the view","enum":["grid","table"],"example":"grid","type":"string"},"name":{"description":"The name of the view","example":"All","type":"string"},"sorts":{"description":"The list of sorts","items":{"$ref":"#/components/schemas/apimodel.Sort"},"type":"array","uniqueItems":false}},"type":"object"},"pagination.PaginatedResponse-apimodel_Member":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Member"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_Object":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Object"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_Property":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Property"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_Space":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Space"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_Tag":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Tag"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_Type":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.Type"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginatedResponse-apimodel_View":{"properties":{"data":{"description":"The list of items in the current result set","items":{"$ref":"#/components/schemas/apimodel.View"},"type":"array","uniqueItems":false},"pagination":{"$ref":"#/components/schemas/pagination.PaginationMeta"}},"type":"object"},"pagination.PaginationMeta":{"description":"The pagination metadata for the response","properties":{"has_more":{"description":"Indicates if there are more items available beyond the current result set","example":true,"type":"boolean"},"limit":{"description":"The maximum number of items returned in the result set","example":100,"type":"integer"},"offset":{"description":"The number of items skipped before starting to collect the result set","example":0,"type":"integer"},"total":{"description":"The total number of items available for the endpoint","example":1000,"type":"integer"}},"type":"object"},"util.ForbiddenError":{"properties":{"code":{"example":"forbidden","type":"string"},"message":{"example":"Forbidden","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":403,"type":"integer"}},"type":"object"},"util.GoneError":{"properties":{"code":{"example":"resource_gone","type":"string"},"message":{"example":"Resource is gone","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":410,"type":"integer"}},"type":"object"},"util.NotFoundError":{"properties":{"code":{"example":"object_not_found","type":"string"},"message":{"example":"Resource not found","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":404,"type":"integer"}},"type":"object"},"util.RateLimitError":{"properties":{"code":{"example":"rate_limit_exceeded","type":"string"},"message":{"example":"Rate limit exceeded","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":429,"type":"integer"}},"type":"object"},"util.ServerError":{"properties":{"code":{"example":"internal_server_error","type":"string"},"message":{"example":"Internal server error","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":500,"type":"integer"}},"type":"object"},"util.UnauthorizedError":{"properties":{"code":{"example":"unauthorized","type":"string"},"message":{"example":"Unauthorized","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":401,"type":"integer"}},"type":"object"},"util.ValidationError":{"properties":{"code":{"example":"bad_request","type":"string"},"message":{"example":"Bad request","type":"string"},"object":{"example":"error","type":"string"},"status":{"example":400,"type":"integer"}},"type":"object"}},"securitySchemes":{"bearerauth":{"bearerFormat":"JWT","scheme":"bearer","type":"http"}}},
-    "info": {"contact":{"email":"support@anytype.io","name":"Anytype Support","url":"https://anytype.io/contact"},"description":"This API empowers seamless interaction with Anytype's resources—spaces, objects, properties, types, templates, and beyond.","license":{"name":"Any Source Available License 1.0","url":"https://github.com/anyproto/anytype-api/blob/main/LICENSE.md"},"termsOfService":"https://anytype.io/terms_of_use","title":"Anytype API","version":"2025-04-22"},
-    "externalDocs": {"description":"OpenAPI","url":"https://swagger.io/resources/open-api/"},
-    "paths": {"/auth/display_code":{"post":{"description":"Generates a one-time authentication challenge for granting API access to the user's vault. Upon providing a valid `app_name`, the server issues a unique `challenge_id` and displays a short code within the Anytype Desktop On success, the service returns a unique challenge ID. This challenge ID must then be used with the token endpoint (see below) to solve the challenge and retrieve an authentication token. This mechanism ensures that only trusted applications and authorized users gain access.","operationId":"createAuthChallenge","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The name of the app requesting API access","in":"query","name":"app_name","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"type":"object"}}}},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.DisplayCodeResponse"}}},"description":"The challenge ID associated with the started challenge"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Invalid input"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"summary":"Start new challenge","tags":["Auth"]}},"/auth/token":{"post":{"description":"After receiving a challenge ID from the display_code endpoint, the client calls this endpoint to provide the corresponding 4-digit code (also via a query parameter) along with the challenge ID. The endpoint verifies that the challenge solution is correct and, if it is, returns a permanent app key. This endpoint is central to the authentication process, as it validates the user's identity and issues a token that can be used for further interactions with the API.","operationId":"solveAuthChallenge","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the challenge to solve","in":"query","name":"challenge_id","required":true,"schema":{"type":"string"}},{"description":"4-digit code retrieved from Anytype Desktop app","in":"query","name":"code","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"type":"object"}}}},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TokenResponse"}}},"description":"The app key that can be used in the Authorization header for subsequent requests"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Invalid input"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"summary":"Solve challenge","tags":["Auth"]}},"/search":{"post":{"description":"Executes a global search over every space accessible by the authenticated user. The request body must specify the `query` text, optional filters on object types (e.g., \"page\", \"task\"), and sort directives (default: descending by last updated timestamp). Pagination is controlled via `offset` and `limit` query parameters to facilitate lazy loading in client UIs. The response returns a unified list of matched objects with their metadata and properties.","operationId":"searchGlobal","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.SearchRequest"}}},"description":"The search parameters used to filter and sort the results","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Object"}}},"description":"The list of objects matching the search criteria"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Search objects across all spaces","tags":["Search"]}},"/spaces":{"get":{"description":"Retrieves a paginated list of all spaces that are accessible by the authenticated user. Each space record contains detailed information such as the space ID, name, icon (derived either from an emoji or image URL), and additional metadata. This endpoint is key to displaying a user’s workspaces.","operationId":"listSpaces","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Space"}}},"description":"The list of spaces accessible by the authenticated user"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List spaces","tags":["Spaces"]},"post":{"description":"Creates a new space based on a supplied name and description in the JSON request body. The endpoint is subject to rate limiting and automatically applies default configurations such as generating a random icon and initializing the workspace with default settings (for example, a default dashboard or home page). On success, the new space’s full metadata is returned, enabling the client to immediately switch context to the new internal.","operationId":"createSpace","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.CreateSpaceRequest"}}},"description":"The space to create","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.SpaceResponse"}}},"description":"The created space"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Create space","tags":["Spaces"]}},"/spaces/{space_id}":{"get":{"description":"Fetches full details about a single space identified by its space ID. The response includes metadata such as the space name, icon, and various workspace IDs (home, archive, profile, etc.). This detailed view supports use cases such as displaying space-specific settings.","operationId":"getSpace","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to retrieve","in":"path","name":"space_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.SpaceResponse"}}},"description":"The space details"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Space not found"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get space","tags":["Spaces"]},"patch":{"description":"Updates the name or description of an existing space. The request body should contain the new name and/or description in JSON format. This endpoint is useful for renaming or rebranding a workspace without needing to recreate it. The updated space’s metadata is returned in the response.","operationId":"updateSpace","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to update","in":"path","name":"space_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.UpdateSpaceRequest"}}},"description":"The space details to update","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.SpaceResponse"}}},"description":"The updated space"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Space not found"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Update space","tags":["Spaces"]}},"/spaces/{space_id}/lists/{list_id}/objects":{"post":{"description":"Adds one or more objects to a specific list (collection only) by submitting a JSON array of object IDs. Upon success, the endpoint returns a confirmation message. This endpoint is vital for building user interfaces that allow drag‑and‑drop or multi‑select additions to collections, enabling users to dynamically manage their collections without needing to modify the underlying object data.","operationId":"addListObjects","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the list belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the list to which objects will be added","in":"path","name":"list_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"items":{"type":"string"},"type":"array"}}},"description":"The list of object IDs to add to the list","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"type":"string"}}},"description":"Objects added successfully"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Not found"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Add objects to list","tags":["Lists"]}},"/spaces/{space_id}/lists/{list_id}/objects/{object_id}":{"delete":{"description":"Removes a given object from the specified list (collection only) in a space. The endpoint takes the space, list, and object identifiers as path parameters and is subject to rate limiting. It is used for dynamically managing collections without affecting the underlying object data.","operationId":"removeListObject","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the list belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the list from which the object will be removed","in":"path","name":"list_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object to remove from the list","in":"path","name":"object_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"type":"string"}}},"description":"Objects removed successfully"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Not found"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Remove object from list","tags":["Lists"]}},"/spaces/{space_id}/lists/{list_id}/views":{"get":{"description":"Returns a paginated list of views defined for a specific list (query or collection) within a space. Each view includes details such as layout, applied filters, and sorting options, enabling clients to render the list according to user preferences and context. This endpoint is essential for applications that need to display lists in various formats (e.g., grid, table) or with different sorting/filtering criteria.","operationId":"getListViews","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the list belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the list to retrieve views for","in":"path","name":"list_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_View"}}},"description":"The list of views associated with the specified list"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Not found"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get list views","tags":["Lists"]}},"/spaces/{space_id}/lists/{list_id}/{view_id}/objects":{"get":{"description":"Returns a paginated list of objects associated with a specific list (query or collection) within a space. When a view ID is provided, the objects are filtered and sorted according to the view's configuration. If no view ID is specified, all list objects are returned without filtering and sorting. This endpoint helps clients to manage grouped objects (for example, tasks within a list) by returning information for each item of the list.","operationId":"getListObjects","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the list belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the list to retrieve objects for","in":"path","name":"list_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the view to retrieve objects for","in":"path","name":"view_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Object"}}},"description":"The list of objects associated with the specified list"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Not found"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get objects in list","tags":["Lists"]}},"/spaces/{space_id}/members":{"get":{"description":"Returns a paginated list of members belonging to the specified space. Each member record includes the member’s profile ID, name, icon (which may be derived from an emoji or image), network identity, global name, status (e.g. joining, active) and role (e.g. Viewer, Editor, Owner). This endpoint supports collaborative features by allowing clients to show who is in a space and manage access rights.","operationId":"listMembers","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to list members for","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Member"}}},"description":"The list of members in the space"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List members","tags":["Members"]}},"/spaces/{space_id}/members/{member_id}":{"get":{"description":"Fetches detailed information about a single member within a space. The endpoint returns the member’s identifier, name, icon, identity, global name, status and role. The member_id path parameter can be provided as either the member's ID (starting  with `_participant`) or the member's identity. This is useful for user profile pages, permission management, and displaying member-specific information in collaborative environments.","operationId":"getMember","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to get the member from","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"Member ID or Identity","in":"path","name":"member_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.MemberResponse"}}},"description":"The member details"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Member not found"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get member","tags":["Members"]}},"/spaces/{space_id}/objects":{"get":{"description":"Retrieves a paginated list of objects in the given space. The endpoint takes query parameters for pagination (offset and limit) and returns detailed data about each object including its ID, name, icon, type information, a snippet of the content (if applicable), layout, space ID, blocks and details. It is intended for building views where users can see all objects in a space at a glance.","operationId":"listObjects","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which to list objects","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Object"}}},"description":"The list of objects in the specified space"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List objects","tags":["Objects"]},"post":{"description":"Creates a new object in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include key details such as the object name, icon, description, body content (which may support Markdown), source URL (required for bookmark objects), template identifier, and the type_key (which is the non-unique identifier of the type of object to create). Post-creation, additional operations (like setting featured properties or fetching bookmark metadata) may occur. The endpoint then returns the full object data, ready for further interactions.","operationId":"createObject","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which to create the object","in":"path","name":"space_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.CreateObjectRequest"}}},"description":"The object to create","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.ObjectResponse"}}},"description":"The created object"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Create object","tags":["Objects"]}},"/spaces/{space_id}/objects/{object_id}":{"delete":{"description":"This endpoint “deletes” an object by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the object’s details after it has been archived. Proper error handling is in place for situations such as when the object isn’t found or the deletion cannot be performed because of permission issues.","operationId":"deleteObject","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which the object exists","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object to delete","in":"path","name":"object_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.ObjectResponse"}}},"description":"The deleted object"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Delete object","tags":["Objects"]},"get":{"description":"Fetches the full details of a single object identified by the object ID within the specified space. The response includes not only basic metadata (ID, name, icon, type) but also the complete set of blocks (which may include text, files, properties and dataviews) and extra details (such as timestamps and linked member information). This endpoint is essential when a client needs to render or edit the full object view.","operationId":"getObject","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which the object exists","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object to retrieve","in":"path","name":"object_id","required":true,"schema":{"type":"string"}},{"description":"The format to return the object body in","in":"query","name":"format","schema":{"default":"\"md\"","enum":["md"],"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.ObjectResponse"}}},"description":"The retrieved object"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get object","tags":["Objects"]},"patch":{"description":"This endpoint updates an existing object in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the details to be updated. The endpoint then returns the full object data, ready for further interactions.","operationId":"updateObject","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which the object exists","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object to update","in":"path","name":"object_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.UpdateObjectRequest"}}},"description":"The details of the object to update","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.ObjectResponse"}}},"description":"The updated object"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Update object","tags":["Objects"]}},"/spaces/{space_id}/properties":{"get":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ Retrieves a paginated list of properties available within a specific space. Each property record includes its unique identifier, name and format. This information is essential for clients to understand the available properties for filtering or creating objects.","operationId":"listProperties","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to list properties for","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Property"}}},"description":"The list of properties in the specified space"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List properties","tags":["Properties"]},"post":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ Creates a new property in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include property details such as the name and format. The endpoint then returns the full property data, ready for further interactions.","operationId":"createProperty","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to create the property in","in":"path","name":"space_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.CreatePropertyRequest"}}},"description":"The property to create","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.PropertyResponse"}}},"description":"The created property"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Create property","tags":["Properties"]}},"/spaces/{space_id}/properties/{property_id}":{"delete":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ This endpoint “deletes” a property by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the property’s details after it has been archived. Proper error handling is in place for situations such as when the property isn’t found or the deletion cannot be performed because of permission issues.","operationId":"deleteProperty","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the property belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to delete","in":"path","name":"property_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.PropertyResponse"}}},"description":"The deleted property"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Delete property","tags":["Properties"]},"get":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ Fetches detailed information about one specific property by its ID. This includes the property’s unique identifier, name and format. This detailed view assists clients in showing property options to users and in guiding the user interface (such as displaying appropriate input fields or selection options).","operationId":"getProperty","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the property belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to retrieve","in":"path","name":"property_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.PropertyResponse"}}},"description":"The requested property"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get property","tags":["Properties"]},"patch":{"description":"⚠ Warning: Properties are experimental and may change in the next update. ⚠ This endpoint updates an existing property in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the name to be updated. The endpoint then returns the full property data, ready for further interactions.","operationId":"updateProperty","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the property belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to update","in":"path","name":"property_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.UpdatePropertyRequest"}}},"description":"The property to update","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.PropertyResponse"}}},"description":"The updated property"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Update property","tags":["Properties"]}},"/spaces/{space_id}/properties/{property_id}/tags":{"get":{"description":"This endpoint retrieves a paginated list of tags available for a specific property within a space. Each tag record includes its unique identifier, name, and color. This information is essential for clients to display select or multi-select options to users when they are creating or editing objects. The endpoint also supports pagination through offset and limit parameters.","operationId":"listTags","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to list tags for","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to list tags for","in":"path","name":"property_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Tag"}}},"description":"The list of tags"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Property not found"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List tags","tags":["Tags"]},"post":{"description":"This endpoint creates a new tag for a given property id in a space. The creation process is subject to rate limiting. The tag is identified by its unique identifier within the specified space. The request must include the tag's name and color. The response includes the tag's details such as its ID, name, and color. This is useful for clients when users want to add new tag options to a property.","operationId":"createTag","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to create the tag in","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to create the tag for","in":"path","name":"property_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.CreateTagRequest"}}},"description":"The tag to create","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TagResponse"}}},"description":"The created tag"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Create tag","tags":["Tags"]}},"/spaces/{space_id}/properties/{property_id}/tags/{tag_id}":{"delete":{"description":"This endpoint “deletes” a tag by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the tag’s details after it has been archived. Proper error handling is in place for situations such as when the tag isn’t found or the deletion cannot be performed because of permission issues.","operationId":"deleteTag","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to delete the tag from","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to delete the tag for","in":"path","name":"property_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the tag to delete","in":"path","name":"tag_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TagResponse"}}},"description":"The deleted tag"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Delete tag","tags":["Tags"]},"get":{"description":"This endpoint retrieves a tag for a given property id. The tag is identified by its unique identifier within the specified space. The response includes the tag's details such as its ID, name, and color. This is useful for clients to display or when editing a specific tag option.","operationId":"getTag","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to retrieve the tag from","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to retrieve the tag for","in":"path","name":"property_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the tag to retrieve","in":"path","name":"tag_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TagResponse"}}},"description":"The retrieved tag"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get tag","tags":["Tags"]},"patch":{"description":"This endpoint updates a tag for a given property id in a space. The update process is subject to rate limiting. The tag is identified by its unique identifier within the specified space. The request must include the tag's name and color. The response includes the tag's details such as its ID, name, and color. This is useful for clients when users want to edit existing tags for a property.","operationId":"updateTag","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to update the tag in","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the property to update the tag for","in":"path","name":"property_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the tag to update","in":"path","name":"tag_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.UpdateTagRequest"}}},"description":"The tag to update","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TagResponse"}}},"description":"The updated tag"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Update tag","tags":["Tags"]}},"/spaces/{space_id}/search":{"post":{"description":"Performs a focused search within a single space (specified by the space_id path parameter). Like the global search, it accepts pagination parameters and a JSON payload containing the search query, object types, and sorting preferences. The search is limited to the provided space and returns a list of objects that match the query. This allows clients to implement space‑specific filtering without having to process extraneous results.","operationId":"searchSpace","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to search in","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.SearchRequest"}}},"description":"The search parameters used to filter and sort the results","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Object"}}},"description":"The list of objects matching the search criteria"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Search objects within a space","tags":["Search"]}},"/spaces/{space_id}/types":{"get":{"description":"This endpoint retrieves a paginated list of object types (e.g. 'Page', 'Note', 'Task') available within the specified space. Each type’s record includes its unique identifier, type key, display name, icon, and layout. While a type's id is truly unique, a type's key can be the same across spaces for known types, e.g. 'page' for 'Page'. Clients use this information when offering choices for object creation or for filtering objects by type through search.","operationId":"listTypes","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to retrieve types from","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Type"}}},"description":"The list of types"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List types","tags":["Types"]},"post":{"description":"Creates a new object type in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include type details such as the name, icon, and layout. The endpoint then returns the full type data, ready to be used for creating objects.","operationId":"createType","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which to create the type","in":"path","name":"space_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.CreateTypeRequest"}}},"description":"The type to create","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TypeResponse"}}},"description":"The created type"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Create type","tags":["Types"]}},"/spaces/{space_id}/types/{type_id}":{"delete":{"description":"This endpoint “deletes” an object type by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the type’s details after it has been archived. Proper error handling is in place for situations such as when the type isn’t found or the deletion cannot be performed because of permission issues.","operationId":"deleteType","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space from which to delete the type","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the type to delete","in":"path","name":"type_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TypeResponse"}}},"description":"The deleted type"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"403":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ForbiddenError"}}},"description":"Forbidden"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Delete type","tags":["Types"]},"get":{"description":"Fetches detailed information about one specific object type by its ID. This includes the type’s unique key, name, icon, and layout. This detailed view assists clients in understanding the expected structure and style for objects of that type and in guiding the user interface (such as displaying appropriate icons or layout hints).","operationId":"getType","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space from which to retrieve the type","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the type to retrieve","in":"path","name":"type_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TypeResponse"}}},"description":"The requested type"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get type","tags":["Types"]},"patch":{"description":"This endpoint updates an existing object type in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the name and properties to be updated. The endpoint then returns the full type data, ready for further interactions.","operationId":"updateType","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space in which the type exists","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the type to update","in":"path","name":"type_id","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.UpdateTypeRequest"}}},"description":"The type details to update","required":true},"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TypeResponse"}}},"description":"The updated type"},"400":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ValidationError"}}},"description":"Bad request"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"429":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.RateLimitError"}}},"description":"Rate limit exceeded"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Update type","tags":["Types"]}},"/spaces/{space_id}/types/{type_id}/templates":{"get":{"description":"This endpoint returns a paginated list of templates that are associated with a specific object type within a space. Templates provide pre‑configured structures for creating new objects. Each template record contains its identifier, name, and icon, so that clients can offer users a selection of templates when creating objects.","operationId":"listTemplates","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the type belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object type to retrieve templates for","in":"path","name":"type_id","required":true,"schema":{"type":"string"}},{"description":"The number of items to skip before starting to collect the result set","in":"query","name":"offset","schema":{"default":0,"type":"integer"}},{"description":"The number of items to return","in":"query","name":"limit","schema":{"default":100,"maximum":1000,"type":"integer"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/pagination.PaginatedResponse-apimodel_Object"}}},"description":"List of templates"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"List templates","tags":["Templates"]}},"/spaces/{space_id}/types/{type_id}/templates/{template_id}":{"get":{"description":"Fetches full details for one template associated with a particular object type in a space. The response provides the template’s identifier, name, icon, and any other relevant metadata. This endpoint is useful when a client needs to preview or apply a template to prefill object creation fields.","operationId":"getTemplate","parameters":[{"description":"The version of the API to use","in":"header","name":"Anytype-Version","required":true,"schema":{"default":"2025-04-22","type":"string"}},{"description":"The ID of the space to which the template belongs","in":"path","name":"space_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the object type to which the template belongs","in":"path","name":"type_id","required":true,"schema":{"type":"string"}},{"description":"The ID of the template to retrieve","in":"path","name":"template_id","required":true,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/apimodel.TemplateResponse"}}},"description":"The requested template"},"401":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.UnauthorizedError"}}},"description":"Unauthorized"},"404":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.NotFoundError"}}},"description":"Resource not found"},"410":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.GoneError"}}},"description":"Resource deleted"},"500":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/util.ServerError"}}},"description":"Internal server error"}},"security":[{"bearerauth":[]}],"summary":"Get template","tags":["Templates"]}}},
-    "openapi": "3.1.0",
-    "servers": [
-        {"url":"http://localhost:31009/v1"}
-    ]
+  "components": {
+    "schemas": {
+      "apimodel.AddObjectsToListRequest": {
+        "properties": {
+          "objects": {
+            "description": "The list of object IDs to add to the list",
+            "example": [
+              "[\"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ\"]"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CheckboxPropertyLinkValue": {
+        "properties": {
+          "checkbox": {
+            "description": "The checkbox value of the property",
+            "example": true,
+            "type": "boolean"
+          },
+          "key": {
+            "example": "done",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CheckboxPropertyValue": {
+        "properties": {
+          "checkbox": {
+            "description": "The checkbox value of the property",
+            "example": true,
+            "type": "boolean"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "done",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Done",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Color": {
+        "description": "The color of the icon",
+        "enum": [
+          "grey",
+          "yellow",
+          "orange",
+          "red",
+          "pink",
+          "purple",
+          "blue",
+          "ice",
+          "teal",
+          "lime"
+        ],
+        "example": "yellow",
+        "type": "string",
+        "x-enum-varnames": [
+          "ColorGrey",
+          "ColorYellow",
+          "ColorOrange",
+          "ColorRed",
+          "ColorPink",
+          "ColorPurple",
+          "ColorBlue",
+          "ColorIce",
+          "ColorTeal",
+          "ColorLime"
+        ]
+      },
+      "apimodel.CreateApiKeyRequest": {
+        "properties": {
+          "challenge_id": {
+            "description": "The challenge id associated with the previously displayed code",
+            "example": "67647f5ecda913e9a2e11b26",
+            "type": "string"
+          },
+          "code": {
+            "description": "The 4-digit code retrieved from Anytype Desktop app",
+            "example": "1234",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CreateApiKeyResponse": {
+        "properties": {
+          "api_key": {
+            "description": "The api key used to authenticate requests",
+            "example": "zhSG/zQRmgADyilWPtgdnfo1qD60oK02/SVgi1GaFt6=",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CreateChallengeRequest": {
+        "properties": {
+          "app_name": {
+            "description": "The name of the app that is requesting the challenge",
+            "example": "anytype_mcp",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CreateChallengeResponse": {
+        "properties": {
+          "challenge_id": {
+            "description": "The challenge id associated with the displayed code and needed to solve the challenge for api_key",
+            "example": "67647f5ecda913e9a2e11b26",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.CreateObjectRequest": {
+        "properties": {
+          "body": {
+            "description": "The body of the object",
+            "example": "This is the body of the object. Markdown syntax is supported here.",
+            "type": "string"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "name": {
+            "description": "The name of the object",
+            "example": "My object",
+            "type": "string"
+          },
+          "properties": {
+            "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set on the object; see ListTypes or GetType endpoints for linked properties",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyLinkWithValue"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "template_id": {
+            "description": "The id of the template to use",
+            "example": "bafyreictrp3obmnf6dwejy5o4p7bderaaia4bdg2psxbfzf44yya5uutge",
+            "type": "string"
+          },
+          "type_key": {
+            "description": "The key of the type of object to create",
+            "example": "page",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type_key"
+        ],
+        "type": "object"
+      },
+      "apimodel.CreatePropertyRequest": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "key": {
+            "description": "The key of the property; should always be snake_case, otherwise it will be converted to snake_case",
+            "example": "some_user_defined_property_key",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Last modified date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "name"
+        ],
+        "type": "object"
+      },
+      "apimodel.CreateSpaceRequest": {
+        "properties": {
+          "description": {
+            "description": "The description of the space",
+            "example": "The local-first wiki",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the space",
+            "example": "New Space",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "apimodel.CreateTagRequest": {
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/apimodel.Color"
+          },
+          "name": {
+            "description": "The name of the tag",
+            "example": "In progress",
+            "type": "string"
+          }
+        },
+        "required": [
+          "color",
+          "name"
+        ],
+        "type": "object"
+      },
+      "apimodel.CreateTypeRequest": {
+        "properties": {
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "key": {
+            "description": "The key of the type; should always be snake_case, otherwise it will be converted to snake_case",
+            "example": "some_user_defined_type_key",
+            "type": "string"
+          },
+          "layout": {
+            "$ref": "#/components/schemas/apimodel.TypeLayout"
+          },
+          "name": {
+            "description": "The name of the type",
+            "example": "Page",
+            "type": "string"
+          },
+          "plural_name": {
+            "description": "The plural name of the type",
+            "example": "Pages",
+            "type": "string"
+          },
+          "properties": {
+            "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties linked to the type",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyLink"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "required": [
+          "layout",
+          "name",
+          "plural_name"
+        ],
+        "type": "object"
+      },
+      "apimodel.DatePropertyLinkValue": {
+        "properties": {
+          "date": {
+            "description": "The date value of the property",
+            "example": "2025-02-14T12:34:56Z",
+            "type": "string"
+          },
+          "key": {
+            "example": "last_modified_date",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.DatePropertyValue": {
+        "properties": {
+          "date": {
+            "description": "The date value of the property",
+            "example": "2025-02-14T12:34:56Z",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "last_modified_date",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Last modified date",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.EmailPropertyLinkValue": {
+        "properties": {
+          "email": {
+            "description": "The email value of the property",
+            "example": "example@example.com",
+            "type": "string"
+          },
+          "key": {
+            "example": "email",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.EmailPropertyValue": {
+        "properties": {
+          "email": {
+            "description": "The email value of the property",
+            "example": "example@example.com",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "email",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Email",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.EmojiIcon": {
+        "properties": {
+          "emoji": {
+            "description": "The emoji of the icon",
+            "example": "📄",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.IconFormat"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.FileIcon": {
+        "properties": {
+          "file": {
+            "description": "The file of the icon",
+            "example": "bafybeieptz5hvcy6txplcvphjbbh5yjc2zqhmihs3owkh5oab4ezauzqay",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.IconFormat"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.FilesPropertyLinkValue": {
+        "properties": {
+          "files": {
+            "description": "The file ids of the property",
+            "example": [
+              "['file_id']"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "key": {
+            "example": "files",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.FilesPropertyValue": {
+        "properties": {
+          "files": {
+            "description": "The file values of the property",
+            "example": [
+              "['file_id']"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "files",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Files",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Filter": {
+        "properties": {
+          "condition": {
+            "description": "The filter condition",
+            "enum": [
+              "equal",
+              "not_equal",
+              "greater",
+              "less",
+              "greater_or_equal",
+              "less_or_equal",
+              "like",
+              "not_like",
+              "in",
+              "not_in",
+              "empty",
+              "not_empty",
+              "all_in",
+              "not_all_in",
+              "exact_in",
+              "not_exact_in",
+              "exists"
+            ],
+            "example": "contains",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the filter",
+            "example": "67bf3f21cda9134102e2422c",
+            "type": "string"
+          },
+          "property_key": {
+            "description": "The property key used for filtering",
+            "example": "name",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value used for filtering",
+            "example": "Some value...",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Icon": {
+        "description": "The icon of the object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/apimodel.EmojiIcon"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.FileIcon"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.NamedIcon"
+          }
+        ],
+        "type": "object"
+      },
+      "apimodel.IconFormat": {
+        "description": "The format of the icon",
+        "enum": [
+          "emoji",
+          "file",
+          "icon"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "IconFormatEmoji",
+          "IconFormatFile",
+          "IconFormatIcon"
+        ]
+      },
+      "apimodel.IconName": {
+        "description": "The name of the icon",
+        "example": "document",
+        "type": "string",
+        "x-enum-varnames": [
+          "IconNameAccessibility",
+          "IconNameAddCircle",
+          "IconNameAirplane",
+          "IconNameAlarm",
+          "IconNameAlbums",
+          "IconNameAlertCircle",
+          "IconNameAmericanFootball",
+          "IconNameAnalytics",
+          "IconNameAperture",
+          "IconNameApps",
+          "IconNameArchive",
+          "IconNameArrowBackCircle",
+          "IconNameArrowDownCircle",
+          "IconNameArrowForwardCircle",
+          "IconNameArrowRedoCircle",
+          "IconNameArrowRedo",
+          "IconNameArrowUndoCircle",
+          "IconNameArrowUndo",
+          "IconNameArrowUpCircle",
+          "IconNameAtCircle",
+          "IconNameAttach",
+          "IconNameBackspace",
+          "IconNameBagAdd",
+          "IconNameBagCheck",
+          "IconNameBagHandle",
+          "IconNameBagRemove",
+          "IconNameBag",
+          "IconNameBalloon",
+          "IconNameBan",
+          "IconNameBandage",
+          "IconNameBarChart",
+          "IconNameBarbell",
+          "IconNameBarcode",
+          "IconNameBaseball",
+          "IconNameBasket",
+          "IconNameBasketball",
+          "IconNameBatteryCharging",
+          "IconNameBatteryDead",
+          "IconNameBatteryFull",
+          "IconNameBatteryHalf",
+          "IconNameBeaker",
+          "IconNameBed",
+          "IconNameBeer",
+          "IconNameBicycle",
+          "IconNameBinoculars",
+          "IconNameBluetooth",
+          "IconNameBoat",
+          "IconNameBody",
+          "IconNameBonfire",
+          "IconNameBook",
+          "IconNameBookmark",
+          "IconNameBookmarks",
+          "IconNameBowlingBall",
+          "IconNameBriefcase",
+          "IconNameBrowsers",
+          "IconNameBrush",
+          "IconNameBug",
+          "IconNameBuild",
+          "IconNameBulb",
+          "IconNameBus",
+          "IconNameBusiness",
+          "IconNameCafe",
+          "IconNameCalculator",
+          "IconNameCalendarClear",
+          "IconNameCalendarNumber",
+          "IconNameCalendar",
+          "IconNameCall",
+          "IconNameCameraReverse",
+          "IconNameCamera",
+          "IconNameCarSport",
+          "IconNameCar",
+          "IconNameCard",
+          "IconNameCaretBackCircle",
+          "IconNameCaretBack",
+          "IconNameCaretDownCircle",
+          "IconNameCaretDown",
+          "IconNameCaretForwardCircle",
+          "IconNameCaretForward",
+          "IconNameCaretUpCircle",
+          "IconNameCaretUp",
+          "IconNameCart",
+          "IconNameCash",
+          "IconNameCellular",
+          "IconNameChatboxEllipses",
+          "IconNameChatbox",
+          "IconNameChatbubbleEllipses",
+          "IconNameChatbubble",
+          "IconNameChatbubbles",
+          "IconNameCheckbox",
+          "IconNameCheckmarkCircle",
+          "IconNameCheckmarkDoneCircle",
+          "IconNameChevronBackCircle",
+          "IconNameChevronDownCircle",
+          "IconNameChevronForwardCircle",
+          "IconNameChevronUpCircle",
+          "IconNameClipboard",
+          "IconNameCloseCircle",
+          "IconNameCloudCircle",
+          "IconNameCloudDone",
+          "IconNameCloudDownload",
+          "IconNameCloudOffline",
+          "IconNameCloudUpload",
+          "IconNameCloud",
+          "IconNameCloudyNight",
+          "IconNameCloudy",
+          "IconNameCodeSlash",
+          "IconNameCode",
+          "IconNameCog",
+          "IconNameColorFill",
+          "IconNameColorFilter",
+          "IconNameColorPalette",
+          "IconNameColorWand",
+          "IconNameCompass",
+          "IconNameConstruct",
+          "IconNameContact",
+          "IconNameContract",
+          "IconNameContrast",
+          "IconNameCopy",
+          "IconNameCreate",
+          "IconNameCrop",
+          "IconNameCube",
+          "IconNameCut",
+          "IconNameDesktop",
+          "IconNameDiamond",
+          "IconNameDice",
+          "IconNameDisc",
+          "IconNameDocumentAttach",
+          "IconNameDocumentLock",
+          "IconNameDocumentText",
+          "IconNameDocument",
+          "IconNameDocuments",
+          "IconNameDownload",
+          "IconNameDuplicate",
+          "IconNameEar",
+          "IconNameEarth",
+          "IconNameEasel",
+          "IconNameEgg",
+          "IconNameEllipse",
+          "IconNameEllipsisHorizontalCircle",
+          "IconNameEllipsisVerticalCircle",
+          "IconNameEnter",
+          "IconNameExit",
+          "IconNameExpand",
+          "IconNameExtensionPuzzle",
+          "IconNameEyeOff",
+          "IconNameEye",
+          "IconNameEyedrop",
+          "IconNameFastFood",
+          "IconNameFemale",
+          "IconNameFileTrayFull",
+          "IconNameFileTrayStacked",
+          "IconNameFileTray",
+          "IconNameFilm",
+          "IconNameFilterCircle",
+          "IconNameFingerPrint",
+          "IconNameFish",
+          "IconNameFitness",
+          "IconNameFlag",
+          "IconNameFlame",
+          "IconNameFlashOff",
+          "IconNameFlash",
+          "IconNameFlashlight",
+          "IconNameFlask",
+          "IconNameFlower",
+          "IconNameFolderOpen",
+          "IconNameFolder",
+          "IconNameFootball",
+          "IconNameFootsteps",
+          "IconNameFunnel",
+          "IconNameGameController",
+          "IconNameGift",
+          "IconNameGitBranch",
+          "IconNameGitCommit",
+          "IconNameGitCompare",
+          "IconNameGitMerge",
+          "IconNameGitNetwork",
+          "IconNameGitPullRequest",
+          "IconNameGlasses",
+          "IconNameGlobe",
+          "IconNameGolf",
+          "IconNameGrid",
+          "IconNameHammer",
+          "IconNameHandLeft",
+          "IconNameHandRight",
+          "IconNameHappy",
+          "IconNameHardwareChip",
+          "IconNameHeadset",
+          "IconNameHeartCircle",
+          "IconNameHeartDislikeCircle",
+          "IconNameHeartDislike",
+          "IconNameHeartHalf",
+          "IconNameHeart",
+          "IconNameHelpBuoy",
+          "IconNameHelpCircle",
+          "IconNameHome",
+          "IconNameHourglass",
+          "IconNameIceCream",
+          "IconNameIdCard",
+          "IconNameImage",
+          "IconNameImages",
+          "IconNameInfinite",
+          "IconNameInformationCircle",
+          "IconNameInvertMode",
+          "IconNameJournal",
+          "IconNameKey",
+          "IconNameKeypad",
+          "IconNameLanguage",
+          "IconNameLaptop",
+          "IconNameLayers",
+          "IconNameLeaf",
+          "IconNameLibrary",
+          "IconNameLink",
+          "IconNameListCircle",
+          "IconNameList",
+          "IconNameLocate",
+          "IconNameLocation",
+          "IconNameLockClosed",
+          "IconNameLockOpen",
+          "IconNameLogIn",
+          "IconNameLogOut",
+          "IconNameLogoAlipay",
+          "IconNameLogoAmazon",
+          "IconNameLogoAmplify",
+          "IconNameLogoAndroid",
+          "IconNameMagnet",
+          "IconNameMailOpen",
+          "IconNameMailUnread",
+          "IconNameMail",
+          "IconNameMaleFemale",
+          "IconNameMale",
+          "IconNameMan",
+          "IconNameMap",
+          "IconNameMedal",
+          "IconNameMedical",
+          "IconNameMedkit",
+          "IconNameMegaphone",
+          "IconNameMenu",
+          "IconNameMicCircle",
+          "IconNameMicOffCircle",
+          "IconNameMicOff",
+          "IconNameMic",
+          "IconNameMoon",
+          "IconNameMove",
+          "IconNameMusicalNote",
+          "IconNameMusicalNotes",
+          "IconNameNavigateCircle",
+          "IconNameNavigate",
+          "IconNameNewspaper",
+          "IconNameNotificationsCircle",
+          "IconNameNotificationsOffCircle",
+          "IconNameNotificationsOff",
+          "IconNameNotifications",
+          "IconNameNuclear",
+          "IconNameNutrition",
+          "IconNameOptions",
+          "IconNamePaperPlane",
+          "IconNamePartlySunny",
+          "IconNamePauseCircle",
+          "IconNamePause",
+          "IconNamePaw",
+          "IconNamePencil",
+          "IconNamePeopleCircle",
+          "IconNamePeople",
+          "IconNamePersonAdd",
+          "IconNamePersonCircle",
+          "IconNamePersonRemove",
+          "IconNamePerson",
+          "IconNamePhoneLandscape",
+          "IconNamePhonePortrait",
+          "IconNamePieChart",
+          "IconNamePin",
+          "IconNamePint",
+          "IconNamePizza",
+          "IconNamePlanet",
+          "IconNamePlayBackCircle",
+          "IconNamePlayBack",
+          "IconNamePlayCircle",
+          "IconNamePlayForwardCircle",
+          "IconNamePlayForward",
+          "IconNamePlaySkipBackCircle",
+          "IconNamePlaySkipBack",
+          "IconNamePlaySkipForwardCircle",
+          "IconNamePlaySkipForward",
+          "IconNamePlay",
+          "IconNamePodium",
+          "IconNamePower",
+          "IconNamePricetag",
+          "IconNamePricetags",
+          "IconNamePrint",
+          "IconNamePrism",
+          "IconNamePulse",
+          "IconNamePush",
+          "IconNameQrCode",
+          "IconNameRadioButtonOff",
+          "IconNameRadioButtonOn",
+          "IconNameRadio",
+          "IconNameRainy",
+          "IconNameReader",
+          "IconNameReceipt",
+          "IconNameRecording",
+          "IconNameRefreshCircle",
+          "IconNameRefresh",
+          "IconNameReloadCircle",
+          "IconNameReload",
+          "IconNameRemoveCircle",
+          "IconNameRepeat",
+          "IconNameResize",
+          "IconNameRestaurant",
+          "IconNameRibbon",
+          "IconNameRocket",
+          "IconNameRose",
+          "IconNameSad",
+          "IconNameSave",
+          "IconNameScale",
+          "IconNameScanCircle",
+          "IconNameScan",
+          "IconNameSchool",
+          "IconNameSearchCircle",
+          "IconNameSearch",
+          "IconNameSend",
+          "IconNameServer",
+          "IconNameSettings",
+          "IconNameShapes",
+          "IconNameShareSocial",
+          "IconNameShare",
+          "IconNameShieldCheckmark",
+          "IconNameShieldHalf",
+          "IconNameShield",
+          "IconNameShirt",
+          "IconNameShuffle",
+          "IconNameSkull",
+          "IconNameSnow",
+          "IconNameSparkles",
+          "IconNameSpeedometer",
+          "IconNameSquare",
+          "IconNameStarHalf",
+          "IconNameStar",
+          "IconNameStatsChart",
+          "IconNameStopCircle",
+          "IconNameStop",
+          "IconNameStopwatch",
+          "IconNameStorefront",
+          "IconNameSubway",
+          "IconNameSunny",
+          "IconNameSwapHorizontal",
+          "IconNameSwapVertical",
+          "IconNameSyncCircle",
+          "IconNameSync",
+          "IconNameTabletLandscape",
+          "IconNameTabletPortrait",
+          "IconNameTelescope",
+          "IconNameTennisball",
+          "IconNameTerminal",
+          "IconNameText",
+          "IconNameThermometer",
+          "IconNameThumbsDown",
+          "IconNameThumbsUp",
+          "IconNameThunderstorm",
+          "IconNameTicket",
+          "IconNameTime",
+          "IconNameTimer",
+          "IconNameToday",
+          "IconNameToggle",
+          "IconNameTrailSign",
+          "IconNameTrain",
+          "IconNameTransgender",
+          "IconNameTrashBin",
+          "IconNameTrash",
+          "IconNameTrendingDown",
+          "IconNameTrendingUp",
+          "IconNameTriangle",
+          "IconNameTrophy",
+          "IconNameTv",
+          "IconNameUmbrella",
+          "IconNameUnlink",
+          "IconNameVideocamOff",
+          "IconNameVideocam",
+          "IconNameVolumeHigh",
+          "IconNameVolumeLow",
+          "IconNameVolumeMedium",
+          "IconNameVolumeMute",
+          "IconNameVolumeOff",
+          "IconNameWalk",
+          "IconNameWallet",
+          "IconNameWarning",
+          "IconNameWatch",
+          "IconNameWater",
+          "IconNameWifi",
+          "IconNameWine",
+          "IconNameWoman"
+        ]
+      },
+      "apimodel.Member": {
+        "description": "The member",
+        "properties": {
+          "global_name": {
+            "description": "The global name of the member in the network",
+            "example": "john.any",
+            "type": "string"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "id": {
+            "description": "The profile object id of the member",
+            "example": "_participant_bafyreigyfkt6rbv24sbv5aq2hko1bhmv5xxlf22b4bypdu6j7hnphm3psq_23me69r569oi1_AAjEaEwPF4nkEh9AWkqEnzcQ8HziBB4ETjiTpvRCQvWnSMDZ",
+            "type": "string"
+          },
+          "identity": {
+            "description": "The identity of the member in the network",
+            "example": "AAjEaEwPF4nkEh7AWkqEnzcQ8HziGB4ETjiTpvRCQvWnSMDZ",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the member",
+            "example": "John Doe",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "member",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the member",
+            "enum": [
+              "viewer",
+              "editor",
+              "owner",
+              "no_permission"
+            ],
+            "example": "owner",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the member",
+            "enum": [
+              "joining",
+              "active",
+              "removed",
+              "declined",
+              "removing",
+              "canceled"
+            ],
+            "example": "active",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.MemberResponse": {
+        "properties": {
+          "member": {
+            "$ref": "#/components/schemas/apimodel.Member"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.MultiSelectPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "tag",
+            "type": "string"
+          },
+          "multi_select": {
+            "description": "The selected tag ids of the property; see ListTags endpoint for valid values",
+            "example": [
+              "['tag_id']"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.MultiSelectPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "tag",
+            "type": "string"
+          },
+          "multi_select": {
+            "description": "The selected tag values of the property",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Tag"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Tag",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.NamedIcon": {
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/apimodel.Color"
+          },
+          "format": {
+            "$ref": "#/components/schemas/apimodel.IconFormat"
+          },
+          "name": {
+            "$ref": "#/components/schemas/apimodel.IconName"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.NumberPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "height",
+            "type": "string"
+          },
+          "number": {
+            "description": "The number value of the property",
+            "example": 42,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.NumberPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "height",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Height",
+            "type": "string"
+          },
+          "number": {
+            "description": "The number value of the property",
+            "example": 42,
+            "type": "number"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Object": {
+        "properties": {
+          "archived": {
+            "description": "Whether the object is archived",
+            "example": false,
+            "type": "boolean"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "id": {
+            "description": "The id of the object",
+            "example": "bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ",
+            "type": "string"
+          },
+          "layout": {
+            "$ref": "#/components/schemas/apimodel.ObjectLayout"
+          },
+          "name": {
+            "description": "The name of the object",
+            "example": "My object",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "object",
+            "type": "string"
+          },
+          "properties": {
+            "description": "The properties of the object",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyWithValue"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "snippet": {
+            "description": "The snippet of the object, especially important for notes as they don't have a name",
+            "example": "The beginning of the object body...",
+            "type": "string"
+          },
+          "space_id": {
+            "description": "The id of the space the object is in",
+            "example": "bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/apimodel.Type"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.ObjectLayout": {
+        "description": "The layout of the object",
+        "example": "basic",
+        "type": "string",
+        "x-enum-varnames": [
+          "ObjectLayoutBasic",
+          "ObjectLayoutProfile",
+          "ObjectLayoutAction",
+          "ObjectLayoutNote",
+          "ObjectLayoutBookmark",
+          "ObjectLayoutSet",
+          "ObjectLayoutCollection",
+          "ObjectLayoutParticipant"
+        ]
+      },
+      "apimodel.ObjectResponse": {
+        "properties": {
+          "object": {
+            "$ref": "#/components/schemas/apimodel.ObjectWithBody"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.ObjectWithBody": {
+        "description": "The object",
+        "properties": {
+          "archived": {
+            "description": "Whether the object is archived",
+            "example": false,
+            "type": "boolean"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "id": {
+            "description": "The id of the object",
+            "example": "bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ",
+            "type": "string"
+          },
+          "layout": {
+            "description": "The layout of the object",
+            "example": "basic",
+            "type": "string",
+            "x-enum-varnames": [
+              "ObjectLayoutBasic",
+              "ObjectLayoutProfile",
+              "ObjectLayoutAction",
+              "ObjectLayoutNote",
+              "ObjectLayoutBookmark",
+              "ObjectLayoutSet",
+              "ObjectLayoutCollection",
+              "ObjectLayoutParticipant"
+            ]
+          },
+          "markdown": {
+            "description": "The markdown body of the object",
+            "example": "# This is the title\n...",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the object",
+            "example": "My object",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "object",
+            "type": "string"
+          },
+          "properties": {
+            "description": "The properties of the object",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyWithValue"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "snippet": {
+            "description": "The snippet of the object, especially important for notes as they don't have a name",
+            "example": "The beginning of the object body...",
+            "type": "string"
+          },
+          "space_id": {
+            "description": "The id of the space the object is in",
+            "example": "bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/apimodel.Type"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.ObjectsPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "creator",
+            "type": "string"
+          },
+          "objects": {
+            "description": "The object ids of the property",
+            "example": [
+              "['object_id']"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.ObjectsPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "creator",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Created by",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          },
+          "objects": {
+            "description": "The object values of the property",
+            "example": [
+              "['object_id']"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.PhonePropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "phone",
+            "type": "string"
+          },
+          "phone": {
+            "description": "The phone value of the property",
+            "example": "+1234567890",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.PhonePropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "phone",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Phone",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          },
+          "phone": {
+            "description": "The phone value of the property",
+            "example": "+1234567890",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Property": {
+        "description": "The property",
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "last_modified_date",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Last modified date",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.PropertyFormat": {
+        "description": "The format of the property used for filtering",
+        "enum": [
+          "text",
+          "number",
+          "select",
+          "multi_select",
+          "date",
+          "files",
+          "checkbox",
+          "url",
+          "email",
+          "phone",
+          "objects"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "PropertyFormatText",
+          "PropertyFormatNumber",
+          "PropertyFormatSelect",
+          "PropertyFormatMultiSelect",
+          "PropertyFormatDate",
+          "PropertyFormatFiles",
+          "PropertyFormatCheckbox",
+          "PropertyFormatUrl",
+          "PropertyFormatEmail",
+          "PropertyFormatPhone",
+          "PropertyFormatObjects"
+        ]
+      },
+      "apimodel.PropertyLink": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "last_modified_date",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Last modified date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "format",
+          "key",
+          "name"
+        ],
+        "type": "object"
+      },
+      "apimodel.PropertyLinkWithValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/apimodel.TextPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.NumberPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.SelectPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.MultiSelectPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.DatePropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.FilesPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.CheckboxPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.URLPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.EmailPropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.PhonePropertyLinkValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.ObjectsPropertyLinkValue"
+          }
+        ],
+        "type": "object"
+      },
+      "apimodel.PropertyResponse": {
+        "properties": {
+          "property": {
+            "$ref": "#/components/schemas/apimodel.Property"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.PropertyWithValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/apimodel.TextPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.NumberPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.SelectPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.MultiSelectPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.DatePropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.FilesPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.CheckboxPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.URLPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.EmailPropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.PhonePropertyValue"
+          },
+          {
+            "$ref": "#/components/schemas/apimodel.ObjectsPropertyValue"
+          }
+        ],
+        "type": "object"
+      },
+      "apimodel.SearchRequest": {
+        "properties": {
+          "query": {
+            "description": "The text to search within object names and content; use types field for type filtering",
+            "example": "test",
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/apimodel.SortOptions"
+          },
+          "types": {
+            "description": "The types of objects to include in results (e.g., \"page\", \"task\", \"bookmark\"); see ListTypes endpoint for valid values",
+            "example": [
+              "page",
+              "task",
+              "bookmark"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.SelectPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "status",
+            "type": "string"
+          },
+          "select": {
+            "description": "The selected tag id of the property; see ListTags endpoint for valid values",
+            "example": "tag_id",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.SelectPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "status",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Status",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          },
+          "select": {
+            "$ref": "#/components/schemas/apimodel.Tag"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Sort": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the sort",
+            "example": "67bf3f21cda9134102e2422c",
+            "type": "string"
+          },
+          "property_key": {
+            "description": "The property key used for sorting",
+            "example": "name",
+            "type": "string"
+          },
+          "sort_type": {
+            "description": "The sort direction",
+            "enum": [
+              "asc",
+              "desc",
+              "custom"
+            ],
+            "example": "asc",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.SortDirection": {
+        "default": "desc",
+        "description": "The direction to sort the search results by",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "Asc",
+          "Desc"
+        ]
+      },
+      "apimodel.SortOptions": {
+        "description": "The sorting options for the search results",
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/apimodel.SortDirection"
+          },
+          "property_key": {
+            "$ref": "#/components/schemas/apimodel.SortProperty"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.SortProperty": {
+        "default": "last_modified_date",
+        "description": "The key of the property to sort the search results by",
+        "enum": [
+          "created_date",
+          "last_modified_date",
+          "last_opened_date",
+          "name"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "CreatedDate",
+          "LastModifiedDate",
+          "LastOpenedDate",
+          "Name"
+        ]
+      },
+      "apimodel.Space": {
+        "description": "The space",
+        "properties": {
+          "description": {
+            "description": "The description of the space",
+            "example": "The local-first wiki",
+            "type": "string"
+          },
+          "gateway_url": {
+            "description": "The gateway url to serve files and media",
+            "example": "http://127.0.0.1:31006",
+            "type": "string"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "id": {
+            "description": "The id of the space",
+            "example": "bafyreigyfkt6rbv24sbv5aq2hko3bhmv5xxlf22b4bypdu6j7hnphm3psq.23me69r569oi1",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the space",
+            "example": "My Space",
+            "type": "string"
+          },
+          "network_id": {
+            "description": "The network id of the space",
+            "example": "N83gJpVd9MuNRZAuJLZ7LiMntTThhPc6DtzWWVjb1M3PouVU",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "space",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.SpaceResponse": {
+        "properties": {
+          "space": {
+            "$ref": "#/components/schemas/apimodel.Space"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Tag": {
+        "description": "The selected tag value of the property",
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/apimodel.Color"
+          },
+          "id": {
+            "description": "The id of the tag",
+            "example": "bafyreiaixlnaefu3ci22zdenjhsdlyaeeoyjrsid5qhfeejzlccijbj7sq",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the tag",
+            "example": "67b0d3e3cda913b84c1299b1",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the tag",
+            "example": "in-progress",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "tag",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.TagResponse": {
+        "properties": {
+          "tag": {
+            "$ref": "#/components/schemas/apimodel.Tag"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.TemplateResponse": {
+        "properties": {
+          "template": {
+            "$ref": "#/components/schemas/apimodel.ObjectWithBody"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.TextPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "description",
+            "type": "string"
+          },
+          "text": {
+            "description": "The text value of the property",
+            "example": "Some text...",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.TextPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "description",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Description",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          },
+          "text": {
+            "description": "The text value of the property",
+            "example": "Some text...",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.Type": {
+        "description": "The type of the object",
+        "properties": {
+          "archived": {
+            "description": "Whether the type is archived",
+            "example": false,
+            "type": "boolean"
+          },
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "id": {
+            "description": "The id of the type (which is unique across spaces)",
+            "example": "bafyreigyb6l5szohs32ts26ku2j42yd65e6hqy2u3gtzgdwqv6hzftsetu",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the type (can be the same across spaces for known types)",
+            "example": "page",
+            "type": "string"
+          },
+          "layout": {
+            "description": "The layout of the object",
+            "enum": [
+              "basic",
+              "profile",
+              "action",
+              "note",
+              "bookmark",
+              "set",
+              "set",
+              "collection",
+              "participant"
+            ],
+            "type": "string",
+            "x-enum-varnames": [
+              "ObjectLayoutBasic",
+              "ObjectLayoutProfile",
+              "ObjectLayoutAction",
+              "ObjectLayoutNote",
+              "ObjectLayoutBookmark",
+              "ObjectLayoutSet",
+              "ObjectLayoutCollection",
+              "ObjectLayoutParticipant"
+            ]
+          },
+          "name": {
+            "description": "The name of the type",
+            "example": "Page",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "type",
+            "type": "string"
+          },
+          "plural_name": {
+            "description": "The plural name of the type",
+            "example": "Pages",
+            "type": "string"
+          },
+          "properties": {
+            "description": "The properties linked to the type",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Property"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.TypeLayout": {
+        "description": "The layout of the type",
+        "enum": [
+          "basic",
+          "profile",
+          "action",
+          "note"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "TypeLayoutBasic",
+          "TypeLayoutProfile",
+          "TypeLayoutAction",
+          "TypeLayoutNote"
+        ]
+      },
+      "apimodel.TypeResponse": {
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/apimodel.Type"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.URLPropertyLinkValue": {
+        "properties": {
+          "key": {
+            "example": "source",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL value of the property",
+            "example": "https://example.com",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.URLPropertyValue": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/apimodel.PropertyFormat"
+          },
+          "id": {
+            "description": "The id of the property",
+            "example": "bafyreids36kpw5ppuwm3ce2p4ezb3ab7cihhkq6yfbwzwpp4mln7rcgw7a",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key of the property",
+            "example": "source",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the property",
+            "example": "Source",
+            "type": "string"
+          },
+          "object": {
+            "description": "The data model of the object",
+            "example": "property",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL value of the property",
+            "example": "https://example.com",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.UpdateObjectRequest": {
+        "properties": {
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "name": {
+            "description": "The name of the object",
+            "example": "My object",
+            "type": "string"
+          },
+          "properties": {
+            "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set for the object; see ListTypes or GetType endpoints for linked properties",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyLinkWithValue"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.UpdatePropertyRequest": {
+        "properties": {
+          "key": {
+            "description": "The key to set for the property; ; should always be snake_case, otherwise it will be converted to snake_case",
+            "example": "some_user_defined_property_key",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name to set for the property",
+            "example": "Last modified date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "apimodel.UpdateSpaceRequest": {
+        "properties": {
+          "description": {
+            "description": "The description of the space",
+            "example": "The local-first wiki",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the space",
+            "example": "New Space",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.UpdateTagRequest": {
+        "properties": {
+          "color": {
+            "$ref": "#/components/schemas/apimodel.Color"
+          },
+          "name": {
+            "description": "The name to set for the tag",
+            "example": "In progress",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.UpdateTypeRequest": {
+        "properties": {
+          "icon": {
+            "$ref": "#/components/schemas/apimodel.Icon"
+          },
+          "key": {
+            "description": "The key to set for the type; should always be snake_case, otherwise it will be converted to snake_case",
+            "example": "some_user_defined_type_key",
+            "type": "string"
+          },
+          "layout": {
+            "$ref": "#/components/schemas/apimodel.TypeLayout"
+          },
+          "name": {
+            "description": "The name to set for the type",
+            "example": "Page",
+            "type": "string"
+          },
+          "plural_name": {
+            "description": "The plural name to set for the type",
+            "example": "Pages",
+            "type": "string"
+          },
+          "properties": {
+            "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ The properties to set for the type",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.PropertyLink"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "apimodel.View": {
+        "properties": {
+          "filters": {
+            "description": "The list of filters",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Filter"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "id": {
+            "description": "The id of the view",
+            "example": "67bf3f21cda9134102e2422c",
+            "type": "string"
+          },
+          "layout": {
+            "description": "The layout of the view",
+            "enum": [
+              "grid",
+              "table"
+            ],
+            "example": "grid",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the view",
+            "example": "All",
+            "type": "string"
+          },
+          "sorts": {
+            "description": "The list of sorts",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Sort"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Member": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Member"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Object": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Object"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Property": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Property"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Space": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Space"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Tag": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Tag"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_Type": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.Type"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginatedResponse-apimodel_View": {
+        "properties": {
+          "data": {
+            "description": "The list of items in the current result set",
+            "items": {
+              "$ref": "#/components/schemas/apimodel.View"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/pagination.PaginationMeta"
+          }
+        },
+        "type": "object"
+      },
+      "pagination.PaginationMeta": {
+        "description": "The pagination metadata for the response",
+        "properties": {
+          "has_more": {
+            "description": "Indicates if there are more items available beyond the current result set",
+            "example": true,
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "The maximum number of items returned in the result set",
+            "example": 100,
+            "type": "integer"
+          },
+          "offset": {
+            "description": "The number of items skipped before starting to collect the result set",
+            "example": 0,
+            "type": "integer"
+          },
+          "total": {
+            "description": "The total number of items available for the endpoint",
+            "example": 1000,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.ForbiddenError": {
+        "properties": {
+          "code": {
+            "example": "forbidden",
+            "type": "string"
+          },
+          "message": {
+            "example": "Forbidden",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 403,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.GoneError": {
+        "properties": {
+          "code": {
+            "example": "resource_gone",
+            "type": "string"
+          },
+          "message": {
+            "example": "Resource is gone",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 410,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.NotFoundError": {
+        "properties": {
+          "code": {
+            "example": "object_not_found",
+            "type": "string"
+          },
+          "message": {
+            "example": "Resource not found",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 404,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.RateLimitError": {
+        "properties": {
+          "code": {
+            "example": "rate_limit_exceeded",
+            "type": "string"
+          },
+          "message": {
+            "example": "Rate limit exceeded",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 429,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.ServerError": {
+        "properties": {
+          "code": {
+            "example": "internal_server_error",
+            "type": "string"
+          },
+          "message": {
+            "example": "Internal server error",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 500,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.UnauthorizedError": {
+        "properties": {
+          "code": {
+            "example": "unauthorized",
+            "type": "string"
+          },
+          "message": {
+            "example": "Unauthorized",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 401,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "util.ValidationError": {
+        "properties": {
+          "code": {
+            "example": "bad_request",
+            "type": "string"
+          },
+          "message": {
+            "example": "Bad request",
+            "type": "string"
+          },
+          "object": {
+            "example": "error",
+            "type": "string"
+          },
+          "status": {
+            "example": 400,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerauth": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "support@anytype.io",
+      "name": "Anytype Support",
+      "url": "https://anytype.io/contact"
+    },
+    "description": "This API enables seamless interaction with Anytype's resources - spaces, objects, properties, types, templates, and beyond.",
+    "license": {
+      "name": "Any Source Available License 1.0",
+      "url": "https://github.com/anyproto/anytype-api/blob/main/LICENSE.md"
+    },
+    "termsOfService": "https://anytype.io/terms_of_use",
+    "title": "Anytype API",
+    "version": "2025-05-20"
+  },
+  "externalDocs": {
+    "description": "OpenAPI",
+    "url": "https://swagger.io/resources/open-api/"
+  },
+  "paths": {
+    "/v1/auth/api_keys": {
+      "post": {
+        "description": "After receiving a `challenge_id` from the `/v1/auth/challenges` endpoint, the client calls this endpoint to provide the corresponding 4-digit code along with the challenge ID. The endpoint verifies that the challenge solution is correct and, if it is, returns an `api_key`. This endpoint is central to the authentication process, as it validates the user's identity and issues a key that can be used for further interactions with the API.",
+        "operationId": "create_api_key",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateApiKeyRequest"
+              }
+            }
+          },
+          "description": "The request body containing the challenge ID and code",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.CreateApiKeyResponse"
+                }
+              }
+            },
+            "description": "The API key that can be used in the Authorization header for subsequent requests"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create API Key",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/auth/challenges": {
+      "post": {
+        "description": "Generates a one-time authentication challenge for granting API access to the user's vault. Upon providing a valid `app_name`, the server issues a unique `challenge_id` and displays a 4-digit code within the Anytype Desktop. The `challenge_id` must then be used with the `/v1/auth/api_keys` endpoint to solve the challenge and retrieve an authentication token. This mechanism ensures that only trusted applications and authorized users gain access.",
+        "operationId": "create_auth_challenge",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateChallengeRequest"
+              }
+            }
+          },
+          "description": "The request body containing the app name",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.CreateChallengeResponse"
+                }
+              }
+            },
+            "description": "The challenge ID associated with the started challenge"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Create Challenge",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/v1/search": {
+      "post": {
+        "description": "Executes a global search over all spaces accessible to the authenticated user. The request body must specify the `query` text (currently matching only name and snippet of an object), optional filters on types (e.g., \"page\", \"task\"), and sort directives (default: descending by last modified date). Pagination is controlled via `offset` and `limit` query parameters to facilitate lazy loading in client UIs. The response returns a unified list of matched objects with their metadata and properties.",
+        "operationId": "search_global",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.SearchRequest"
+              }
+            }
+          },
+          "description": "The search parameters used to filter and sort the results",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Object"
+                }
+              }
+            },
+            "description": "The list of objects matching the search criteria"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Search objects across all spaces",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/v1/spaces": {
+      "get": {
+        "description": "Retrieves a paginated list of all spaces that are accessible by the authenticated user. Each space record contains detailed information such as the space ID, name, icon (derived either from an emoji or image URL), and additional metadata. This endpoint is key to displaying a user’s workspaces.",
+        "operationId": "list_spaces",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Space"
+                }
+              }
+            },
+            "description": "The list of spaces accessible by the authenticated user"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List spaces",
+        "tags": [
+          "Spaces"
+        ]
+      },
+      "post": {
+        "description": "Creates a new space based on a supplied name and description in the JSON request body. The endpoint is subject to rate limiting and automatically applies default configurations such as generating a random icon and initializing the workspace with default settings (for example, a default dashboard or home page). On success, the new space’s full metadata is returned, enabling the client to immediately switch context to the new internal.",
+        "operationId": "create_space",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateSpaceRequest"
+              }
+            }
+          },
+          "description": "The space to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.SpaceResponse"
+                }
+              }
+            },
+            "description": "The created space"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Create space",
+        "tags": [
+          "Spaces"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}": {
+      "get": {
+        "description": "Fetches full details about a single space identified by its space ID. The response includes metadata such as the space name, icon, and various workspace IDs (home, archive, profile, etc.). This detailed view supports use cases such as displaying space-specific settings.",
+        "operationId": "get_space",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to retrieve; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.SpaceResponse"
+                }
+              }
+            },
+            "description": "The space details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Space not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get space",
+        "tags": [
+          "Spaces"
+        ]
+      },
+      "patch": {
+        "description": "Updates the name or description of an existing space. The request body should contain the new name and/or description in JSON format. This endpoint is useful for renaming or rebranding a workspace without needing to recreate it. The updated space’s metadata is returned in the response.",
+        "operationId": "update_space",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to update; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.UpdateSpaceRequest"
+              }
+            }
+          },
+          "description": "The space details to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.SpaceResponse"
+                }
+              }
+            },
+            "description": "The updated space"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Space not found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Update space",
+        "tags": [
+          "Spaces"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/lists/{list_id}/objects": {
+      "post": {
+        "description": "Adds one or more objects to a specific list (collection only) by submitting a JSON array of object IDs. Upon success, the endpoint returns a confirmation message. This endpoint is vital for building user interfaces that allow drag‑and‑drop or multi‑select additions to collections, enabling users to dynamically manage their collections without needing to modify the underlying object data.",
+        "operationId": "add_list_objects",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the list belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the list to which objects will be added; must be retrieved from SearchSpace endpoint with types: ['collection', 'set']",
+            "in": "path",
+            "name": "list_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.AddObjectsToListRequest"
+              }
+            }
+          },
+          "description": "The list of object IDs to add to the list; must be retrieved from SearchSpace or GlobalSearch endpoints or obtained from response context",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Objects added successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Add objects to list",
+        "tags": [
+          "Lists"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/lists/{list_id}/objects/{object_id}": {
+      "delete": {
+        "description": "Removes a given object from the specified list (collection only) in a space. The endpoint takes the space, list, and object identifiers as path parameters and is subject to rate limiting. It is used for dynamically managing collections without affecting the underlying object data.",
+        "operationId": "remove_list_object",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the list belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the list from which the object will be removed; must be retrieved from SearchSpace endpoint with types: ['collection', 'set']",
+            "in": "path",
+            "name": "list_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the object to remove from the list; must be retrieved from SearchSpace or GlobalSearch endpoints or obtained from response context",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Objects removed successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Remove object from list",
+        "tags": [
+          "Lists"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/lists/{list_id}/views": {
+      "get": {
+        "description": "Returns a paginated list of views defined for a specific list (query or collection) within a space. Each view includes details such as layout, applied filters, and sorting options, enabling clients to render the list according to user preferences and context. This endpoint is essential for applications that need to display lists in various formats (e.g., grid, table) or with different sorting/filtering criteria.",
+        "operationId": "get_list_views",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the list belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the list to retrieve views for; must be retrieved from SearchSpace endpoint with types: ['collection', 'set']",
+            "in": "path",
+            "name": "list_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_View"
+                }
+              }
+            },
+            "description": "The list of views associated with the specified list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get list views",
+        "tags": [
+          "Lists"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/lists/{list_id}/views/{view_id}/objects": {
+      "get": {
+        "description": "Returns a paginated list of objects associated with a specific list (query or collection) within a space. When a view ID is provided, the objects are filtered and sorted according to the view's configuration. If no view ID is specified, all list objects are returned without filtering and sorting. This endpoint helps clients to manage grouped objects (for example, tasks within a list) by returning information for each item of the list.",
+        "operationId": "get_list_objects",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the list belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the list to retrieve objects for; must be retrieved from SearchSpace endpoint with types: ['collection', 'set']",
+            "in": "path",
+            "name": "list_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the view to retrieve objects for; must be retrieved from ListViews endpoint or omitted if you want to get all objects in the list",
+            "in": "path",
+            "name": "view_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Object"
+                }
+              }
+            },
+            "description": "The list of objects associated with the specified list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get objects in list",
+        "tags": [
+          "Lists"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/members": {
+      "get": {
+        "description": "Returns a paginated list of members belonging to the specified space. Each member record includes the member’s profile ID, name, icon (which may be derived from an emoji or image), network identity, global name, status (e.g. joining, active) and role (e.g. Viewer, Editor, Owner). This endpoint supports collaborative features by allowing clients to show who is in a space and manage access rights.",
+        "operationId": "list_members",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to list members for; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Member"
+                }
+              }
+            },
+            "description": "The list of members in the space"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List members",
+        "tags": [
+          "Members"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/members/{member_id}": {
+      "get": {
+        "description": "Fetches detailed information about a single member within a space. The endpoint returns the member’s identifier, name, icon, identity, global name, status and role. The member_id path parameter can be provided as either the member's ID (starting  with `_participant`) or the member's identity. This is useful for user profile pages, permission management, and displaying member-specific information in collaborative environments.",
+        "operationId": "get_member",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to get the member from; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Member ID or Identity; must be retrieved from ListMembers endpoint or obtained from response context",
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.MemberResponse"
+                }
+              }
+            },
+            "description": "The member details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Member not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get member",
+        "tags": [
+          "Members"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/objects": {
+      "get": {
+        "description": "Retrieves a paginated list of objects in the given space. The endpoint takes query parameters for pagination (offset and limit) and returns detailed data about each object including its ID, name, icon, type information, a snippet of the content (if applicable), layout, space ID, blocks and details. It is intended for building views where users can see all objects in a space at a glance.",
+        "operationId": "list_objects",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which to list objects; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Object"
+                }
+              }
+            },
+            "description": "The list of objects in the specified space"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List objects",
+        "tags": [
+          "Objects"
+        ]
+      },
+      "post": {
+        "description": "Creates a new object in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include key details such as the object name, icon, description, body content (which may support Markdown), source URL (required for bookmark objects), template identifier, and the type_key (which is the non-unique identifier of the type of object to create). Post-creation, additional operations (like setting featured properties or fetching bookmark metadata) may occur. The endpoint then returns the full object data, ready for further interactions.",
+        "operationId": "create_object",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which to create the object; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateObjectRequest"
+              }
+            }
+          },
+          "description": "The object to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.ObjectResponse"
+                }
+              }
+            },
+            "description": "The created object"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Create object",
+        "tags": [
+          "Objects"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/objects/{object_id}": {
+      "delete": {
+        "description": "This endpoint “deletes” an object by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the object’s details after it has been archived. Proper error handling is in place for situations such as when the object isn’t found or the deletion cannot be performed because of permission issues.",
+        "operationId": "delete_object",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which the object exists; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the object to delete; must be retrieved from ListObjects, SearchSpace or GlobalSearch endpoints or obtained from response context",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.ObjectResponse"
+                }
+              }
+            },
+            "description": "The deleted object"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Delete object",
+        "tags": [
+          "Objects"
+        ]
+      },
+      "get": {
+        "description": "Fetches the full details of a single object identified by the object ID within the specified space. The response includes not only basic metadata (ID, name, icon, type) but also the complete set of blocks (which may include text, files, properties and dataviews) and extra details (such as timestamps and linked member information). This endpoint is essential when a client needs to render or edit the full object view.",
+        "operationId": "get_object",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which the object exists; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the object to retrieve; must be retrieved from ListObjects, SearchSpace or GlobalSearch endpoints or obtained from response context",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The format to return the object body in",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "\"md\"",
+              "enum": [
+                "md"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.ObjectResponse"
+                }
+              }
+            },
+            "description": "The retrieved object"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get object",
+        "tags": [
+          "Objects"
+        ]
+      },
+      "patch": {
+        "description": "This endpoint updates an existing object in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the details to be updated. The endpoint then returns the full object data, ready for further interactions.",
+        "operationId": "update_object",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which the object exists; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the object to update; must be retrieved from ListObjects, SearchSpace or GlobalSearch endpoints or obtained from response context",
+            "in": "path",
+            "name": "object_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.UpdateObjectRequest"
+              }
+            }
+          },
+          "description": "The details of the object to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.ObjectResponse"
+                }
+              }
+            },
+            "description": "The updated object"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Update object",
+        "tags": [
+          "Objects"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/properties": {
+      "get": {
+        "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ Retrieves a paginated list of properties available within a specific space. Each property record includes its unique identifier, name and format. This information is essential for clients to understand the available properties for filtering or creating objects.",
+        "operationId": "list_properties",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to list properties for; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Property"
+                }
+              }
+            },
+            "description": "The list of properties in the specified space"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List properties",
+        "tags": [
+          "Properties"
+        ]
+      },
+      "post": {
+        "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ Creates a new property in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include property details such as the name and format. The endpoint then returns the full property data, ready for further interactions.",
+        "operationId": "create_property",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to create the property in; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreatePropertyRequest"
+              }
+            }
+          },
+          "description": "The property to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.PropertyResponse"
+                }
+              }
+            },
+            "description": "The created property"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Create property",
+        "tags": [
+          "Properties"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/properties/{property_id}": {
+      "delete": {
+        "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ This endpoint “deletes” a property by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the property’s details after it has been archived. Proper error handling is in place for situations such as when the property isn’t found or the deletion cannot be performed because of permission issues.",
+        "operationId": "delete_property",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the property belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to delete; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.PropertyResponse"
+                }
+              }
+            },
+            "description": "The deleted property"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Delete property",
+        "tags": [
+          "Properties"
+        ]
+      },
+      "get": {
+        "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ Fetches detailed information about one specific property by its ID. This includes the property’s unique identifier, name and format. This detailed view assists clients in showing property options to users and in guiding the user interface (such as displaying appropriate input fields or selection options).",
+        "operationId": "get_property",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the property belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to retrieve; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.PropertyResponse"
+                }
+              }
+            },
+            "description": "The requested property"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get property",
+        "tags": [
+          "Properties"
+        ]
+      },
+      "patch": {
+        "description": "⚠ Warning: Properties are experimental and may change in the next update. ⚠ This endpoint updates an existing property in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the name to be updated. The endpoint then returns the full property data, ready for further interactions.",
+        "operationId": "update_property",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the property belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to update; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.UpdatePropertyRequest"
+              }
+            }
+          },
+          "description": "The property to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.PropertyResponse"
+                }
+              }
+            },
+            "description": "The updated property"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Update property",
+        "tags": [
+          "Properties"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/properties/{property_id}/tags": {
+      "get": {
+        "description": "This endpoint retrieves a paginated list of tags available for a specific property within a space. Each tag record includes its unique identifier, name, and color. This information is essential for clients to display select or multi-select options to users when they are creating or editing objects. The endpoint also supports pagination through offset and limit parameters.",
+        "operationId": "list_tags",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to list tags for; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to list tags for; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Tag"
+                }
+              }
+            },
+            "description": "The list of tags"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Property not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List tags",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "post": {
+        "description": "This endpoint creates a new tag for a given property id in a space. The creation process is subject to rate limiting. The tag is identified by its unique identifier within the specified space. The request must include the tag's name and color. The response includes the tag's details such as its ID, name, and color. This is useful for clients when users want to add new tag options to a property.",
+        "operationId": "create_tag",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to create the tag in; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to create the tag for; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateTagRequest"
+              }
+            }
+          },
+          "description": "The tag to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TagResponse"
+                }
+              }
+            },
+            "description": "The created tag"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Create tag",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/properties/{property_id}/tags/{tag_id}": {
+      "delete": {
+        "description": "This endpoint “deletes” a tag by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the tag’s details after it has been archived. Proper error handling is in place for situations such as when the tag isn’t found or the deletion cannot be performed because of permission issues.",
+        "operationId": "delete_tag",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to delete the tag from; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to delete the tag for; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the tag to delete; must be retrieved from ListTags endpoint or obtained from response context",
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TagResponse"
+                }
+              }
+            },
+            "description": "The deleted tag"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Delete tag",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "get": {
+        "description": "This endpoint retrieves a tag for a given property id. The tag is identified by its unique identifier within the specified space. The response includes the tag's details such as its ID, name, and color. This is useful for clients to display or when editing a specific tag option.",
+        "operationId": "get_tag",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to retrieve the tag from; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to retrieve the tag for; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the tag to retrieve; must be retrieved from ListTags endpoint or obtained from response context",
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TagResponse"
+                }
+              }
+            },
+            "description": "The retrieved tag"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get tag",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "patch": {
+        "description": "This endpoint updates a tag for a given property id in a space. The update process is subject to rate limiting. The tag is identified by its unique identifier within the specified space. The request must include the tag's name and color. The response includes the tag's details such as its ID, name, and color. This is useful for clients when users want to edit existing tags for a property.",
+        "operationId": "update_tag",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to update the tag in; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the property to update the tag for; must be retrieved from ListProperties endpoint or obtained from response context",
+            "in": "path",
+            "name": "property_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the tag to update; must be retrieved from ListTags endpoint or obtained from response context",
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.UpdateTagRequest"
+              }
+            }
+          },
+          "description": "The tag to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TagResponse"
+                }
+              }
+            },
+            "description": "The updated tag"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Update tag",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/search": {
+      "post": {
+        "description": "Performs a search within a single space (specified by the `space_id` path parameter). Like the global search, it accepts pagination parameters and a JSON payload containing the search `query`, `types`, and sorting preferences. The search is limited to the provided space and returns a list of objects that match the query. This allows clients to implement space‑specific filtering without having to process extraneous results.",
+        "operationId": "search_space",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to search in; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.SearchRequest"
+              }
+            }
+          },
+          "description": "The search parameters used to filter and sort the results",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Object"
+                }
+              }
+            },
+            "description": "The list of objects matching the search criteria"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Search objects within a space",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/types": {
+      "get": {
+        "description": "This endpoint retrieves a paginated list of types (e.g. 'Page', 'Note', 'Task') available within the specified space. Each type’s record includes its unique identifier, type key, display name, icon, and layout. While a type's id is truly unique, a type's key can be the same across spaces for known types, e.g. 'page' for 'Page'. Clients use this information when offering choices for object creation or for filtering objects by type through search.",
+        "operationId": "list_types",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to retrieve types from; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Type"
+                }
+              }
+            },
+            "description": "The list of types"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List types",
+        "tags": [
+          "Types"
+        ]
+      },
+      "post": {
+        "description": "Creates a new type in the specified space using a JSON payload. The creation process is subject to rate limiting. The payload must include type details such as the name, icon, and layout. The endpoint then returns the full type data, ready to be used for creating objects.",
+        "operationId": "create_type",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which to create the type; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.CreateTypeRequest"
+              }
+            }
+          },
+          "description": "The type to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TypeResponse"
+                }
+              }
+            },
+            "description": "The created type"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Create type",
+        "tags": [
+          "Types"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/types/{type_id}": {
+      "delete": {
+        "description": "This endpoint “deletes” an type by marking it as archived. The deletion process is performed safely and is subject to rate limiting. It returns the type’s details after it has been archived. Proper error handling is in place for situations such as when the type isn’t found or the deletion cannot be performed because of permission issues.",
+        "operationId": "delete_type",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space from which to delete the type; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the type to delete; must be retrieved from ListTypes endpoint or obtained from response context",
+            "in": "path",
+            "name": "type_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TypeResponse"
+                }
+              }
+            },
+            "description": "The deleted type"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ForbiddenError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Delete type",
+        "tags": [
+          "Types"
+        ]
+      },
+      "get": {
+        "description": "Fetches detailed information about one specific type by its ID. This includes the type’s unique key, name, icon, and layout. This detailed view assists clients in understanding the expected structure and style for objects of that type and in guiding the user interface (such as displaying appropriate icons or layout hints).",
+        "operationId": "get_type",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space from which to retrieve the type; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the type to retrieve; must be retrieved from ListTypes endpoint or obtained from response context",
+            "in": "path",
+            "name": "type_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TypeResponse"
+                }
+              }
+            },
+            "description": "The requested type"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get type",
+        "tags": [
+          "Types"
+        ]
+      },
+      "patch": {
+        "description": "This endpoint updates an existing type in the specified space using a JSON payload. The update process is subject to rate limiting. The payload must include the name and properties to be updated. The endpoint then returns the full type data, ready for further interactions.",
+        "operationId": "update_type",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space in which the type exists; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the type to update; must be retrieved from ListTypes endpoint or obtained from response context",
+            "in": "path",
+            "name": "type_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/apimodel.UpdateTypeRequest"
+              }
+            }
+          },
+          "description": "The type details to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TypeResponse"
+                }
+              }
+            },
+            "description": "The updated type"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ValidationError"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.RateLimitError"
+                }
+              }
+            },
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Update type",
+        "tags": [
+          "Types"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/types/{type_id}/templates": {
+      "get": {
+        "description": "This endpoint returns a paginated list of templates that are associated with a specific type within a space. Templates provide pre‑configured structures for creating new objects. Each template record contains its identifier, name, and icon, so that clients can offer users a selection of templates when creating objects.",
+        "operationId": "list_templates",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the type belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the type to retrieve templates for; must be retrieved from ListTypes endpoint or obtained from response context",
+            "in": "path",
+            "name": "type_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip before starting to collect the result set",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pagination.PaginatedResponse-apimodel_Object"
+                }
+              }
+            },
+            "description": "List of templates"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "List templates",
+        "tags": [
+          "Templates"
+        ]
+      }
+    },
+    "/v1/spaces/{space_id}/types/{type_id}/templates/{template_id}": {
+      "get": {
+        "description": "Fetches full details for one template associated with a particular type in a space. The response provides the template’s identifier, name, icon, and any other relevant metadata. This endpoint is useful when a client needs to preview or apply a template to prefill object creation fields.",
+        "operationId": "get_template",
+        "parameters": [
+          {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "Anytype-Version",
+            "required": true,
+            "schema": {
+              "default": "2025-05-20",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the space to which the template belongs; must be retrieved from ListSpaces endpoint",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the type to which the template belongs; must be retrieved from ListTypes endpoint or obtained from response context",
+            "in": "path",
+            "name": "type_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the template to retrieve; must be retrieved from ListTemplates endpoint or obtained from response context",
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/apimodel.TemplateResponse"
+                }
+              }
+            },
+            "description": "The requested template"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.UnauthorizedError"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.NotFoundError"
+                }
+              }
+            },
+            "description": "Resource not found"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.GoneError"
+                }
+              }
+            },
+            "description": "Resource deleted"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/util.ServerError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearerauth": []
+          }
+        ],
+        "summary": "Get template",
+        "tags": [
+          "Templates"
+        ]
+      }
+    }
+  },
+  "openapi": "3.1.0",
+  "servers": [
+    {
+      "url": "http://127.0.0.1:31009"
+    }
+  ]
 }

--- a/tests_api_coverage/update_api_definition.sh
+++ b/tests_api_coverage/update_api_definition.sh
@@ -3,7 +3,7 @@
 # It will fetch the latest API endpoints from the server and update the api_definition.json file.
 # https://github.com/anyproto/anytype-heart/blob/main/core/api/docs/swagger.json
 
-curl https://raw.githubusercontent.com/anyproto/anytype-heart/refs/heads/main/core/api/docs/swagger.json -o api_definition.json
+curl https://raw.githubusercontent.com/anyproto/anytype-heart/refs/heads/main/core/api/docs/openapi.json -o api_definition.json
 if [ $? -ne 0 ]; then
     echo "Failed to fetch the API definition file."
     exit 1


### PR DESCRIPTION
Following anytype-heart move from swagger.json to openapi.json:

- Updated update_api_definition.sh to fetch the latest OpenAPI definition from the new URL.
- Added OperationID field to EndpointInfo struct for better tracking of API operations.
- Updated extractEndpoints function to extract operationId from API definition.
- Modified inferMethodNames to utilize operationId for generating method names.